### PR TITLE
Remove scaffolded API

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -4,64 +4,41 @@ class ItemsController < ApplicationController
   before_action :set_item, only: [:show, :edit, :update, :destroy]
   before_action :set_wishlist, only: [:search, :search_amazon, :results]
 
-  # GET /items
-  # GET /items.json
   def index
     @items = Item.all
   end
 
-  # GET /items/1
-  # GET /items/1.json
   def show
   end
 
-  # GET /items/new
   def new
     @item = Item.new
   end
 
-  # GET /items/1/edit
   def edit
   end
 
-  # POST /items
-  # POST /items.json
   def create
     @item = Item.new(item_params)
 
-    respond_to do |format|
-      if @item.save
-        format.html { redirect_to @item, notice: 'Item was successfully created.' }
-        format.json { render :show, status: :created, location: @item }
-      else
-        format.html { render :new }
-        format.json { render json: @item.errors, status: :unprocessable_entity }
-      end
+    if @item.save
+      redirect_to @item, notice: 'Item was successfully created.'
+    else
+      render :new
     end
   end
 
-  # PATCH/PUT /items/1
-  # PATCH/PUT /items/1.json
   def update
-    respond_to do |format|
-      if @item.update(item_params)
-        format.html { redirect_to @item, notice: 'Item was successfully updated.' }
-        format.json { render :show, status: :ok, location: @item }
-      else
-        format.html { render :edit }
-        format.json { render json: @item.errors, status: :unprocessable_entity }
-      end
+    if @item.update(item_params)
+      redirect_to @item, notice: 'Item was successfully updated.'
+    else
+      render :edit
     end
   end
 
-  # DELETE /items/1
-  # DELETE /items/1.json
   def destroy
     @item.destroy
-    respond_to do |format|
-      format.html { redirect_to items_url, notice: 'Item was successfully destroyed.' }
-      format.json { head :no_content }
-    end
+    redirect_to items_url, notice: 'Item was successfully destroyed.'
   end
 
   def search_amazon
@@ -81,7 +58,7 @@ class ItemsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def item_params
-      params.require(:item).permit(:amazon_url, :associate_url, :price_cents, :asin, :image_url, :staff_message)
+      params.require(:item).permit(:amazon_url, :associate_url, :price_cents, :asin, :image_url)
     end
 
     def amazon_client

--- a/app/controllers/pledges_controller.rb
+++ b/app/controllers/pledges_controller.rb
@@ -2,68 +2,45 @@ class PledgesController < ApplicationController
   before_action :set_pledge, only: [:show, :edit, :update, :destroy]
   before_action :authenticate_admin
 
-  # GET /pledges
-  # GET /pledges.json
   def index
     @pledges = Pledge.all
   end
 
-  # GET /pledges/1
-  # GET /pledges/1.json
   def show
   end
 
-  # GET /pledges/new
   def new
     @pledge = Pledge.new
   end
 
-  # GET /pledges/1/edit
   def edit
   end
 
-  # POST /pledges
-  # POST /pledges.json
   def create
     @pledge = Pledge.new(pledge_params)
 
-    respond_to do |format|
-      if @pledge.save
-        format.html { redirect_to @pledge, notice: 'Pledge was successfully created.' }
-        format.json { render :show, status: :created, location: @pledge }
-      else
-        format.html { render :new }
-        format.json { render json: @pledge.errors, status: :unprocessable_entity }
-      end
+    if @pledge.save
+      redirect_to @pledge, notice: 'Pledge was successfully created.'
+    else
+      render :new
     end
   end
 
-  # PATCH/PUT /pledges/1
-  # PATCH/PUT /pledges/1.json
   def update
-    respond_to do |format|
-      if @pledge.update(pledge_params)
-        format.html { redirect_to @pledge, notice: 'Pledge was successfully updated.' }
-        format.json { render :show, status: :ok, location: @pledge }
-      else
-        format.html { render :edit }
-        format.json { render json: @pledge.errors, status: :unprocessable_entity }
-      end
+    if @pledge.update(pledge_params)
+      redirect_to @pledge, notice: 'Pledge was successfully updated.'
+    else
+      render :edit
     end
   end
 
-  # DELETE /pledges/1
-  # DELETE /pledges/1.json
   def destroy
     @pledge.destroy
-    respond_to do |format|
-      format.html { redirect_to pledges_url, notice: 'Pledge was successfully destroyed.' }
-      format.json { head :no_content }
-    end
+    redirect_to pledges_url, notice: 'Pledge was successfully destroyed.'
   end
 
   def export_csv
-    send_data Pledge.generate_csv, filename: "pledge_data#{Time.now.to_i}.csv"
+    send_data(Pledge.generate_csv, filename: "pledge_data#{Time.now.to_i}.csv")
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,43 +2,27 @@ class UsersController < ApplicationController
   before_action :set_user, only: [:show, :edit, :update, :destroy]
   before_action :authenticate_admin
 
-  # GET /users
-  # GET /users.json
   def index
     @users = User.all
   end
 
-  # GET /users/1
-  # GET /users/1.json
   def show
   end
 
-  # GET /users/1/edit
   def edit
   end
 
-  # PATCH/PUT /users/1
-  # PATCH/PUT /users/1.json
   def update
-    respond_to do |format|
-      if @user.update(user_params)
-        format.html { redirect_to @user, notice: 'User was successfully updated.' }
-        format.json { render :show, status: :ok, location: @user }
-      else
-        format.html { render :edit }
-        format.json { render json: @user.errors, status: :unprocessable_entity }
-      end
+    if @user.update(user_params)
+      redirect_to @user, notice: 'User was successfully updated.'
+    else
+      render :edit
     end
   end
 
-  # DELETE /users/1
-  # DELETE /users/1.json
   def destroy
     @user.destroy
-    respond_to do |format|
-      format.html { redirect_to users_url, notice: 'User was successfully destroyed.' }
-      format.json { head :no_content }
-    end
+    redirect_to users_url, notice: 'User was successfully destroyed.'
   end
 
   def export_csv

--- a/app/controllers/wishlist_items_controller.rb
+++ b/app/controllers/wishlist_items_controller.rb
@@ -29,34 +29,27 @@ class WishlistItemsController < ApplicationController
   end
 
   def update
-    respond_to do |format|
-      if @wishlist_item.update(wishlist_item_params)
-        format.html { redirect_to @wishlist_item.wishlist, notice: 'Wishlist item was successfully updated.' }
-        format.json { render :show, status: :ok, location: @wishlist_item.wishlist }
-      else
-        format.html { render :edit }
-        format.json { render json: @wishlist_item.errors, status: :unprocessable_entity }
-      end
+    if @wishlist_item.update(wishlist_item_params)
+      redirect_to @wishlist_item.wishlist, notice: 'Wishlist item was successfully updated.'
+    else
+      render :edit
     end
   end
 
   def destroy
     wishlist = @wishlist_item.wishlist
     @wishlist_item.destroy
-    respond_to do |format|
-      format.html { redirect_to wishlist, notice: 'Item was successfully removed from wishlist.' }
-      format.json { head :no_content }
-    end
+
+    redirect_to wishlist, notice: 'Item was successfully removed from wishlist.'
   end
 
   private
+    def set_wishlist_item
+      @wishlist_item = WishlistItem.find(params[:id])
+    end
 
-  def set_wishlist_item
-    @wishlist_item = WishlistItem.find(params[:id])
-  end
-
-  # Never trust parameters from the scary internet, only allow the white list through.
-  def wishlist_item_params
-    params.require(:wishlist_item).permit(:quantity, :priority, :staff_message)
-  end
+    # Never trust parameters from the scary internet, only allow the white list through.
+    def wishlist_item_params
+      params.require(:wishlist_item).permit(:quantity, :priority, :staff_message)
+    end
 end

--- a/app/controllers/wishlists_controller.rb
+++ b/app/controllers/wishlists_controller.rb
@@ -3,70 +3,47 @@ class WishlistsController < ApplicationController
   before_action :authenticate_admin, except: [:index, :show]
   helper_method :get_site_managers
 
-  # GET /wishlists
-  # GET /wishlists.json
   def index
     @wishlists = Wishlist.all
   end
 
-  # GET /wishlists/1
-  # GET /wishlists/1.json
   def show
     @site_managers = @wishlist.users
     @wishlist_items = @wishlist.wishlist_items
   end
 
-  # GET /wishlists/new
   def new
     @wishlist = Wishlist.new
     @site_managers = User.where(site_manager: true)
   end
 
-  # GET /wishlists/1/edit
   def edit
     @site_managers = User.where(site_manager: true)
   end
 
-  # POST /wishlists
-  # POST /wishlists.json
   def create
     @wishlist = Wishlist.new(wishlist_params)
 
-    respond_to do |format|
-      if @wishlist.save
-        create_site_managers
-        format.html { redirect_to @wishlist, notice: 'Wishlist was successfully created.' }
-        format.json { render :show, status: :created, location: @wishlist }
-      else
-        format.html { render :new }
-        format.json { render json: @wishlist.errors, status: :unprocessable_entity }
-      end
+    if @wishlist.save
+      create_site_managers
+      redirect_to @wishlist, notice: 'Wishlist was successfully created.'
+    else
+      render :new
     end
   end
 
-  # PATCH/PUT /wishlists/1
-  # PATCH/PUT /wishlists/1.json
   def update
-    respond_to do |format|
-      update_site_managers
-      if @wishlist.update(wishlist_params)
-        format.html { redirect_to @wishlist, notice: 'Wishlist was successfully updated.' }
-        format.json { render :show, status: :ok, location: @wishlist }
-      else
-        format.html { render :edit }
-        format.json { render json: @wishlist.errors, status: :unprocessable_entity }
-      end
+    update_site_managers
+    if @wishlist.update(wishlist_params)
+      redirect_to @wishlist, notice: 'Wishlist was successfully updated.'
+    else
+      render :edit
     end
   end
 
-  # DELETE /wishlists/1
-  # DELETE /wishlists/1.json
   def destroy
     @wishlist.destroy
-    respond_to do |format|
-      format.html { redirect_to root_path, notice: 'Wishlist was successfully destroyed.' }
-      format.json { head :no_content }
-    end
+    redirect_to root_path, notice: 'Wishlist was successfully destroyed.'
   end
 
   private

--- a/app/views/items/_item.json.jbuilder
+++ b/app/views/items/_item.json.jbuilder
@@ -1,2 +1,0 @@
-json.extract! item, :id, :amazon_url, :associate_url, :price_cents, :asin, :created_at, :updated_at
-json.url item_url(item, format: :json)

--- a/app/views/items/index.json.jbuilder
+++ b/app/views/items/index.json.jbuilder
@@ -1,1 +1,0 @@
-json.array! @items, partial: 'items/item', as: :item

--- a/app/views/items/show.json.jbuilder
+++ b/app/views/items/show.json.jbuilder
@@ -1,1 +1,0 @@
-json.partial! "items/item", item: @item


### PR DESCRIPTION
Resolves #57

The Rails scaffold generator generates code for a json api in the
controller and the views. Because of this, we had an out-of-date
partially-implemented API cluttering up our controller.

This commit removes the `respond_to` blocks and the `.json.jbuilder`
files so that our controllers are easier to read and maintain.

If we choose to have an API, we can add it deliberately in the future.