### PR TITLE
Use pundit for authorization

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem 'httparty'
 gem 'social-share-button'
 # most important gem for awesome debugging and awesome consoles
 gem 'pry'
+gem 'pundit'
 
 gem 'font-awesome-sass'
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,6 +149,8 @@ GEM
       slop (~> 3.4)
     public_suffix (2.0.5)
     puma (3.8.2)
+    pundit (1.1.0)
+      activesupport (>= 3.0.0)
     rack (2.0.3)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -276,6 +278,7 @@ DEPENDENCIES
   pg (~> 0.18)
   pry
   puma (~> 3.7)
+  pundit
   rails (~> 5.1.1)
   rollbar
   rspec-rails (~> 3.5)

--- a/app/controllers/amazon_search_controller.rb
+++ b/app/controllers/amazon_search_controller.rb
@@ -1,19 +1,28 @@
 require "amazon_product_api"
 
 class AmazonSearchController < ApplicationController
-  skip_before_action :authenticate_admin
-  before_action :authenticate_site_manager
+  before_action :set_wishlist
 
   def show
+    authorize :amazon_search, :show?
     @response = amazon_client.search_response
   end
 
   def new
+    authorize :amazon_search, :new?
   end
 
   private
     def amazon_client
       AmazonProductAPI::HTTPClient.new(query: params[:query],
                                        page_num: params[:page_num] || 1)
+    end
+
+    def set_wishlist
+      @wishlist = Wishlist.find(params[:wishlist_id])
+    end
+
+    def pundit_user
+      NestedWishlistContext.new(current_user, @wishlist)
     end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,32 +1,17 @@
 class ApplicationController < ActionController::Base
+  include Pundit
   protect_from_forgery with: :exception
 
   helper_method :current_user
   before_action :set_wishlists # required for the nav menu
 
-  # Require admin status by default.
-  #
-  # To override for a view, add:
-  #
-  #     `skip_before_action :authenticate_admin, only: [...]`
-  #
-  # to your controller
-  before_action :authenticate_admin
+  after_action :verify_authorized
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
   private
     def current_user
       return @current_user if @current_user
       @current_user = User.find_by(id: session[:user_id]) || GuestUser.new
-    end
-
-    def authenticate_admin
-      user_not_authorized unless current_user.admin?
-    end
-
-    def authenticate_site_manager(wishlist_id: :wishlist_id)
-      @wishlist = @wishlist_item.try(:wishlist) ||
-        Wishlist.find_by(id: params[wishlist_id])
-      user_not_authorized unless current_user.can_manage?(@wishlist)
     end
 
     def set_wishlists

--- a/app/controllers/pledges_controller.rb
+++ b/app/controllers/pledges_controller.rb
@@ -2,6 +2,7 @@ class PledgesController < ApplicationController
   before_action :set_pledge, only: [:show, :edit, :update, :destroy]
 
   def index
+    authorize Pledge
     respond_to do |format|
       format.html { @pledges = Pledge.all }
       format.csv  { export_csv }
@@ -9,16 +10,20 @@ class PledgesController < ApplicationController
   end
 
   def show
+    authorize @pledge
   end
 
   def new
+    authorize Pledge
     @pledge = Pledge.new
   end
 
   def edit
+    authorize @pledge
   end
 
   def create
+    authorize Pledge
     @pledge = Pledge.new(pledge_params)
 
     if @pledge.save
@@ -29,6 +34,7 @@ class PledgesController < ApplicationController
   end
 
   def update
+    authorize @pledge
     if @pledge.update(pledge_params)
       redirect_to @pledge, notice: 'Pledge was successfully updated.'
     else
@@ -37,6 +43,7 @@ class PledgesController < ApplicationController
   end
 
   def destroy
+    authorize @pledge
     @pledge.destroy
     redirect_to pledges_url, notice: 'Pledge was successfully destroyed.'
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,5 @@
 class SessionsController < ApplicationController
-  skip_before_action :authenticate_admin
+  before_action :skip_authorization
 
   def new
     if current_user.logged_in?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,6 +2,7 @@ class UsersController < ApplicationController
   before_action :set_user, only: [:show, :edit, :update, :destroy]
 
   def index
+    authorize User
     respond_to do |format|
       format.html { @users = User.all }
       format.csv  { export_csv }
@@ -9,12 +10,15 @@ class UsersController < ApplicationController
   end
 
   def show
+    authorize @user
   end
 
   def edit
+    authorize @user
   end
 
   def update
+    authorize @user
     if wishlist_ids = params[:user][:wishlist_ids]
       @user.wishlist_ids = wishlist_ids
     end
@@ -27,6 +31,7 @@ class UsersController < ApplicationController
   end
 
   def destroy
+    authorize @user
     @user.destroy
     redirect_to users_url, notice: 'User was successfully destroyed.'
   end

--- a/app/controllers/wishlist_items_controller.rb
+++ b/app/controllers/wishlist_items_controller.rb
@@ -1,15 +1,16 @@
 class WishlistItemsController < ApplicationController
   before_action :set_wishlist_item, only: [:edit, :update, :destroy]
 
-  skip_before_action :authenticate_admin
-  before_action :authenticate_site_manager, except: [:index]
-
   def index
+    skip_authorization
     @wishlist_items = WishlistItem.all
   end
 
   def create
-    @item =
+    @wishlist = Wishlist.find(params[:wishlist_id])
+    authorize @wishlist.wishlist_items.build
+
+    item =
       Item.find_by_asin(params[:asin]) ||
       Item.create!(
         asin: params[:asin],
@@ -20,17 +21,20 @@ class WishlistItemsController < ApplicationController
         image_height: params[:image_height],
         name: params[:name])
     @wishlist_item = @wishlist.wishlist_items.create!(
-      item: @item,
+      item: item,
       quantity: params[:qty],
       staff_message: params[:staff_message])
 
-    redirect_to wishlist_path(@wishlist), notice: "Added #{@item.name}"
+    redirect_to wishlist_path(@wishlist), notice: "Added #{item.name}"
   end
 
   def edit
+    authorize @wishlist_item
   end
 
   def update
+    authorize @wishlist_item
+
     if @wishlist_item.update(wishlist_item_params)
       redirect_to @wishlist_item.wishlist, notice: 'Wishlist item was successfully updated.'
     else
@@ -39,6 +43,8 @@ class WishlistItemsController < ApplicationController
   end
 
   def destroy
+    authorize @wishlist_item
+
     wishlist = @wishlist_item.wishlist
     @wishlist_item.destroy
 

--- a/app/controllers/wishlists_controller.rb
+++ b/app/controllers/wishlists_controller.rb
@@ -1,22 +1,25 @@
 class WishlistsController < ApplicationController
   before_action :set_wishlist, only: [:show, :edit, :update, :destroy]
-  skip_before_action :authenticate_admin, only: [:show]
 
   def show
+    skip_authorization
     @site_managers = @wishlist.users
     @wishlist_items = @wishlist.wishlist_items
   end
 
   def new
+    authorize Wishlist
     @wishlist = Wishlist.new
     @admins = User.admin
   end
 
   def edit
+    authorize @wishlist
     @admins = User.admin
   end
 
   def create
+    authorize Wishlist
     @wishlist = Wishlist.new(wishlist_params)
     attach_site_managers
 
@@ -28,6 +31,7 @@ class WishlistsController < ApplicationController
   end
 
   def update
+    authorize @wishlist
     attach_site_managers
     if @wishlist.update(wishlist_params)
       redirect_to @wishlist, notice: 'Wishlist was successfully updated.'
@@ -37,6 +41,7 @@ class WishlistsController < ApplicationController
   end
 
   def destroy
+    authorize @wishlist
     @wishlist.destroy
     redirect_to root_path, notice: 'Wishlist was successfully destroyed.'
   end

--- a/app/policies/amazon_search_policy.rb
+++ b/app/policies/amazon_search_policy.rb
@@ -1,0 +1,30 @@
+class AmazonSearchPolicy
+  def initialize(context, amazon_search)
+    @user = context.user
+    @wishlist = context.wishlist
+    @amazon_search = amazon_search
+  end
+
+  def show?
+    new?
+  end
+
+  def new?
+    user.can_manage? wishlist
+  end
+
+  private
+
+  attr_reader :user, :wishlist, :amazon_search
+end
+
+# Required for AmazonSearchPolicy
+#
+# The AmazonSearchController is a modelless, nested controller under Wishlist.
+# Because it's not associated with a model, we're missing the context for the
+# parent wishlist. This encapsulates that context.
+#
+# For more information, see:
+#   https://github.com/elabs/pundit#headless-policies
+#
+NestedWishlistContext = Struct.new(:user, :wishlist)

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,53 @@
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    user.admin?
+  end
+
+  def show?
+    scope.where(id: record.id).exists? && user.admin?
+  end
+
+  def create?
+    user.admin?
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    user.admin?
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    user.admin?
+  end
+
+  def scope
+    Pundit.policy_scope!(user, record.class)
+  end
+
+  class Scope
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      scope
+    end
+  end
+end

--- a/app/policies/pledge_policy.rb
+++ b/app/policies/pledge_policy.rb
@@ -1,0 +1,7 @@
+class PledgePolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      scope
+    end
+  end
+end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,0 +1,7 @@
+class UserPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      scope
+    end
+  end
+end

--- a/app/policies/wishlist_item_policy.rb
+++ b/app/policies/wishlist_item_policy.rb
@@ -1,0 +1,26 @@
+class WishlistItemPolicy < ApplicationPolicy
+  def initialize(user, wishlist_item)
+    @user = user
+    @wishlist = wishlist_item.wishlist
+  end
+
+  def index?
+    true
+  end
+
+  def create?
+    user.can_manage? wishlist
+  end
+
+  def update?
+    user.can_manage? wishlist
+  end
+
+  def destroy?
+    user.can_manage? wishlist
+  end
+
+  private
+
+  attr_reader :user, :wishlist
+end

--- a/app/policies/wishlist_policy.rb
+++ b/app/policies/wishlist_policy.rb
@@ -1,0 +1,22 @@
+class WishlistPolicy < ApplicationPolicy
+  def initialize(user, wishlist)
+    @user = user
+    @wishlist = wishlist
+  end
+
+  def show?
+    true
+  end
+
+  def update?
+    user.admin?
+  end
+
+  def destroy?
+    user.admin?
+  end
+
+  private
+
+  attr_reader :user, :wishlist
+end

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -1,41 +1,41 @@
 <% if item.valid? %>
   <tr class="item">
     <%= form_tag wishlist_wishlist_items_path(wishlist: @wishlist) do %>
-    <%= hidden_field_tag 'name', item.title %>
-    <%= hidden_field_tag 'amazon_url', item.detail_page_url %>
-    <%= hidden_field_tag 'price_cents', item.price_cents %>
-    <%= hidden_field_tag 'asin', item.asin %>
-    <%= hidden_field_tag 'image_url', item.image_url %>
-    <%= hidden_field_tag 'image_width', item.image_width %>
-    <%= hidden_field_tag 'image_height', item.image_height %>
+      <%= hidden_field_tag 'name', item.title %>
+      <%= hidden_field_tag 'amazon_url', item.detail_page_url %>
+      <%= hidden_field_tag 'price_cents', item.price_cents %>
+      <%= hidden_field_tag 'asin', item.asin %>
+      <%= hidden_field_tag 'image_url', item.image_url %>
+      <%= hidden_field_tag 'image_width', item.image_width %>
+      <%= hidden_field_tag 'image_height', item.image_height %>
 
-    <td>
-      <% if item.has_valid_image? %>
-        <%= image_tag item.image_url, width: item.image_width,
-                                      height: item.image_height %>
-      <% end %>
-    </td>
+      <td>
+        <% if item.has_valid_image? %>
+          <%= image_tag item.image_url, width: item.image_width,
+                                        height: item.image_height %>
+        <% end %>
+      </td>
 
-    <td>
-      <%= link_to item.title, item.detail_page_url, target: "_blank" %>
-    </td>
-    <td>
-      <%= item.price %>
-    </td>
+      <td>
+        <%= link_to item.title, item.detail_page_url, target: "_blank" %>
+      </td>
+      <td>
+        <%= item.price %>
+      </td>
 
-    <td>
-      <%= text_field_tag "staff_message" %>
-    </td>
-    <td>
-      <%= select_tag "qty", options_for_select(Array(0..20)) %>
-    </td>
-    <td>
-      <%= select_tag "priority", options_for_select(WishlistItem.priorities.keys) %>
-    </td>
+      <td>
+        <%= text_field_tag "staff_message" %>
+      </td>
+      <td>
+        <%= select_tag "qty", options_for_select(Array(0..20)) %>
+      </td>
+      <td>
+        <%= select_tag "priority", options_for_select(WishlistItem.priorities.keys) %>
+      </td>
 
-    <td>
-      <%= submit_tag "Add" %>
-    </td>
+      <td>
+        <%= submit_tag "Add" %>
+      </td>
     <% end %>
   </tr>
 <% end %>

--- a/spec/policies/amazon_search_policy_spec.rb
+++ b/spec/policies/amazon_search_policy_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+describe AmazonSearchPolicy do
+  subject { described_class }
+
+  permissions :show? do
+    it "denies access to guests" do
+      context = NestedWishlistContext.new(GuestUser.new, create(:wishlist))
+      expect(subject).not_to permit(context, :amazon_search)
+    end
+
+    it "denies access to users" do
+      context = NestedWishlistContext.new(create(:user), create(:wishlist))
+      expect(subject).not_to permit(context, :amazon_search)
+    end
+
+    it "denies access to site managers of different sites" do
+      context = NestedWishlistContext.new(create(:user, :with_sites),
+                                          create(:wishlist))
+      expect(subject).not_to permit(context, :amazon_search)
+    end
+
+    it "grants access to site admin of current site" do
+      wishlist = create(:wishlist)
+      context = NestedWishlistContext.new(create(:user, wishlists: [wishlist]),
+                                          wishlist)
+      expect(subject).to permit(context, :amazon_search)
+    end
+
+    it "grants access to admins" do
+      context = NestedWishlistContext.new(create(:admin), create(:wishlist))
+      expect(subject).to permit(context, :amazon_search)
+    end
+  end
+
+  permissions :new? do
+    it "denies access to guests" do
+      context = NestedWishlistContext.new(GuestUser.new, create(:wishlist))
+      expect(subject).not_to permit(context, :amazon_search)
+    end
+
+    it "denies access to users" do
+      context = NestedWishlistContext.new(create(:user), create(:wishlist))
+      expect(subject).not_to permit(context, :amazon_search)
+    end
+
+    it "denies access to site managers of different sites" do
+      context = NestedWishlistContext.new(create(:user, :with_sites),
+                                          create(:wishlist))
+      expect(subject).not_to permit(context, :amazon_search)
+    end
+
+    it "grants access to site admin of current site" do
+      wishlist = create(:wishlist)
+      context = NestedWishlistContext.new(create(:user, wishlists: [wishlist]),
+                                          wishlist)
+      expect(subject).to permit(context, :amazon_search)
+    end
+
+    it "grants access to admins" do
+      context = NestedWishlistContext.new(create(:admin), create(:wishlist))
+      expect(subject).to permit(context, :amazon_search)
+    end
+  end
+end

--- a/spec/policies/pledge_policy_spec.rb
+++ b/spec/policies/pledge_policy_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+describe PledgePolicy do
+  subject { described_class }
+
+  permissions :index? do
+    it "denies access to guests" do
+      expect(subject).not_to permit(GuestUser.new, Pledge)
+    end
+
+    it "denies access to users" do
+      expect(subject).not_to permit(build(:user), Pledge)
+    end
+
+    it "grants access to admins" do
+      expect(subject).to permit(build(:admin), Pledge)
+    end
+  end
+
+  permissions :show? do
+    it "denies access to guests" do
+      expect(subject).not_to permit(GuestUser.new, create(:pledge))
+    end
+
+    it "denies access to users" do
+      expect(subject).not_to permit(build(:user), create(:pledge))
+    end
+
+    it "grants access to admins" do
+      expect(subject).to permit(build(:admin), create(:pledge))
+    end
+  end
+
+  permissions :create? do
+    it "denies access to guests" do
+      expect(subject).not_to permit(GuestUser.new, Pledge)
+    end
+
+    it "denies access to users" do
+      expect(subject).not_to permit(build(:user), Pledge)
+    end
+
+    it "grants access to admins" do
+      expect(subject).to permit(build(:admin), Pledge)
+    end
+  end
+
+  permissions :update? do
+    it "denies access to guests" do
+      expect(subject).not_to permit(GuestUser.new, build(:pledge))
+    end
+
+    it "denies access to users" do
+      expect(subject).not_to permit(build(:user), build(:pledge))
+    end
+
+    it "grants access to admins" do
+      expect(subject).to permit(build(:admin), build(:pledge))
+    end
+  end
+
+  permissions :destroy? do
+    it "denies access to guests" do
+      expect(subject).not_to permit(GuestUser.new, build(:pledge))
+    end
+
+    it "denies access to users" do
+      expect(subject).not_to permit(build(:user), build(:pledge))
+    end
+
+    it "grants access to admins" do
+      expect(subject).to permit(build(:admin), build(:pledge))
+    end
+  end
+end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+describe UserPolicy do
+  subject { described_class }
+
+  permissions :index? do
+    it "denies access to guests" do
+      expect(subject).not_to permit(GuestUser.new, User)
+    end
+
+    it "denies access to users" do
+      expect(subject).not_to permit(build(:user), User)
+    end
+
+    it "grants access to admins" do
+      expect(subject).to permit(build(:admin), User)
+    end
+  end
+
+  permissions :show? do
+    it "denies access to guests" do
+      expect(subject).not_to permit(GuestUser.new, create(:user))
+    end
+
+    it "denies access to users" do
+      expect(subject).not_to permit(build(:user), create(:user))
+    end
+
+    it "denies access to the given user" do
+      user = create(:user)
+      expect(subject).not_to permit(user, user)
+    end
+
+    it "grants access to admins" do
+      expect(subject).to permit(build(:admin), create(:user))
+    end
+  end
+
+  permissions :update? do
+    it "denies access to guests" do
+      expect(subject).not_to permit(GuestUser.new, build(:user))
+    end
+
+    it "denies access to users" do
+      expect(subject).not_to permit(build(:user), build(:user))
+    end
+
+    it "denies access to the given user" do
+      user = build(:user)
+      expect(subject).not_to permit(user, user)
+    end
+
+    it "grants access to admins" do
+      expect(subject).to permit(build(:admin), build(:user))
+    end
+  end
+
+  permissions :destroy? do
+    it "denies access to guests" do
+      expect(subject).not_to permit(GuestUser.new, build(:user))
+    end
+
+    it "denies access to users" do
+      expect(subject).not_to permit(build(:user), build(:user))
+    end
+
+    it "denies access to the given user" do
+      user = build(:user)
+      expect(subject).not_to permit(user, user)
+    end
+
+    it "grants access to admins" do
+      expect(subject).to permit(build(:admin), build(:user))
+    end
+  end
+end

--- a/spec/policies/wishlist_item_policy_spec.rb
+++ b/spec/policies/wishlist_item_policy_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+describe WishlistItemPolicy do
+
+  let(:wishlist) { create(:wishlist, :with_item) }
+  let(:wishlist_item) { wishlist.wishlist_items.first }
+
+  subject { described_class }
+
+  permissions :index? do
+    it "grants access to guests" do
+      expect(subject).to permit(GuestUser.new, wishlist_item)
+    end
+  end
+
+  permissions :create? do
+    it "denies access to guests" do
+      expect(subject).not_to permit(GuestUser.new, wishlist_item)
+    end
+
+    it "denies access to normal users" do
+      expect(subject).not_to permit(build(:user), wishlist_item)
+    end
+
+    it "denies access to site managers of different wishlists" do
+      site_manager = create(:user, :with_sites)
+      expect(subject).not_to permit(site_manager, wishlist_item)
+    end
+
+    it "grants access to site managers of the current wishlist" do
+      site_manager = create(:user, wishlists: [wishlist])
+      expect(subject).to permit(site_manager, wishlist_item)
+    end
+
+    it "grants access to admins" do
+      expect(subject).to permit(build(:admin), wishlist_item)
+    end
+  end
+
+  permissions :update? do
+    it "denies access to guests" do
+      expect(subject).not_to permit(GuestUser.new, wishlist_item)
+    end
+
+    it "denies access to normal users" do
+      expect(subject).not_to permit(build(:user), wishlist_item)
+    end
+
+    it "denies access to site managers of different wishlists" do
+      site_manager = create(:user, :with_sites)
+      expect(subject).not_to permit(site_manager, wishlist_item)
+    end
+
+    it "grants access to site managers of the current wishlist" do
+      site_manager = create(:user, wishlists: [wishlist])
+      expect(subject).to permit(site_manager, wishlist_item)
+    end
+
+    it "grants access to admins" do
+      expect(subject).to permit(build(:admin), wishlist_item)
+    end
+  end
+
+  permissions :destroy? do
+    it "denies access to guests" do
+      expect(subject).not_to permit(GuestUser.new, wishlist_item)
+    end
+
+    it "denies access to normal users" do
+      expect(subject).not_to permit(build(:user), wishlist_item)
+    end
+
+    it "denies access to site managers of different wishlists" do
+      site_manager = create(:user, :with_sites)
+      expect(subject).not_to permit(site_manager, wishlist_item)
+    end
+
+    it "grants access to site managers of the current wishlist" do
+      site_manager = create(:user, wishlists: [wishlist])
+      expect(subject).to permit(site_manager, wishlist_item)
+    end
+
+    it "grants access to admins" do
+      expect(subject).to permit(build(:admin), wishlist_item)
+    end
+  end
+end

--- a/spec/policies/wishlist_policy_spec.rb
+++ b/spec/policies/wishlist_policy_spec.rb
@@ -1,0 +1,102 @@
+require 'rails_helper'
+
+describe WishlistPolicy do
+  subject { described_class }
+
+  permissions :show? do
+    it "grants access to all" do
+      expect(subject).to permit(nil, Wishlist)
+    end
+  end
+
+  permissions :new? do
+    it "denies access to guests" do
+      expect(subject).not_to permit(GuestUser.new, Wishlist)
+    end
+
+    it "denies access to users" do
+      expect(subject).not_to permit(build(:user), Wishlist)
+    end
+
+    it "grants access to admins" do
+      expect(subject).to permit(build(:admin), Wishlist)
+    end
+  end
+
+  permissions :edit? do
+    let(:wishlist) { create(:wishlist) }
+
+    it "denies access to guests" do
+      expect(subject).not_to permit(GuestUser.new, wishlist)
+    end
+
+    it "denies access to normal users" do
+      expect(subject).not_to permit(build(:user), wishlist)
+    end
+
+    it "denies access to site managers" do
+      site_manager = create(:user, wishlists: [wishlist])
+      expect(subject).not_to permit(site_manager, wishlist)
+    end
+
+    it "grants access to admins" do
+      expect(subject).to permit(build(:admin), wishlist)
+    end
+  end
+
+  permissions :create? do
+    it "denies access to guests" do
+      expect(subject).not_to permit(GuestUser.new, Wishlist)
+    end
+
+    it "denies access to users" do
+      expect(subject).not_to permit(build(:user), Wishlist)
+    end
+
+    it "grants access to admins" do
+      expect(subject).to permit(build(:admin), Wishlist)
+    end
+  end
+
+  permissions :update? do
+    let(:wishlist) { create(:wishlist) }
+
+    it "denies access to guests" do
+      expect(subject).not_to permit(GuestUser.new, wishlist)
+    end
+
+    it "denies access to normal users" do
+      expect(subject).not_to permit(build(:user), wishlist)
+    end
+
+    it "denies access to site managers" do
+      site_manager = create(:user, wishlists: [wishlist])
+      expect(subject).not_to permit(site_manager, wishlist)
+    end
+
+    it "grants access to admins" do
+      expect(subject).to permit(build(:admin), wishlist)
+    end
+  end
+
+  permissions :destroy? do
+    let(:wishlist) { create(:wishlist) }
+
+    it "denies access to guests" do
+      expect(subject).not_to permit(GuestUser.new, wishlist)
+    end
+
+    it "denies access to normal users" do
+      expect(subject).not_to permit(build(:user), wishlist)
+    end
+
+    it "denies access to site managers" do
+      site_manager = create(:user, wishlists: [wishlist])
+      expect(subject).not_to permit(site_manager, wishlist)
+    end
+
+    it "grants access to admins" do
+      expect(subject).to permit(build(:admin), wishlist)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,7 @@ require File.expand_path('../../config/environment', __FILE__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
+require 'pundit/rspec'
 require 'support/factory_girl'
 require 'support/database_cleaner'
 require 'support/webmock'
@@ -31,7 +32,7 @@ ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  # config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false


### PR DESCRIPTION
Managing and testing our authorization logic is getting complicated, and it'll get more complicated as users are allowed to view their user pages, etc. Pundit makes that simpler by extracting authorization into policy objects. I think this change makes sense, but we should discuss whether this is the route we want to take.

* Do you all think it's worth adding a dependency to separate out auth logic?