### PR TITLE
Last Admin Can't Delete Account (Resolves #55)

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -33,7 +33,7 @@ class UsersController < ApplicationController
 
   def destroy
     authorize @user
-    if User.admin.count < 2
+    if User.admin.count < 2 && @user.admin?
       redirect_to users_url, notice: 'This account is the only remaining Admin user. Please assign another Admin before deleting this account'
       return
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -33,8 +33,11 @@ class UsersController < ApplicationController
 
   def destroy
     authorize @user
+    if User.admin.count < 2
+      redirect_to users_url, notice: 'This account is the only remaining Admin user. Please assign another Admin before deleting this account'
+      return
+    end
     @user.destroy
-
     if current_user == @user
       reset_session
       redirect_to root_url, notice: 'You have successfully deleted your account.'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -33,7 +33,7 @@ class UsersController < ApplicationController
 
   def destroy
     authorize @user
-    if User.admin.count < 2 && @user.admin?
+    if @user.admin? && User.admin.count < 2
       redirect_to users_url, notice: 'This account is the only remaining Admin user. Please assign another Admin before deleting this account'
       return
     end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -12,6 +12,13 @@ describe UsersController do
       admin: false,
     }
   }
+  let(:valid_attributes_admin) {
+    {
+      name: "Pete Conrad",
+      email: "pconrad@nasa.gov",
+      admin: true,
+    }
+  }
 
   let(:invalid_attributes) { {email: nil} }
 
@@ -162,6 +169,12 @@ describe UsersController do
         user = User.create! valid_attributes
         delete :destroy, params: {id: user.to_param}, session: admin_session
         expect(response).to redirect_to(users_url)
+      end
+
+      it "does not allow the last admin to delete their account" do
+        expect(User.admin.count).to eq 1
+        delete :destroy, params: {id: admin.to_param}, session: admin_session
+        expect(User.admin).to exist
       end
     end
   end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -12,13 +12,6 @@ describe UsersController do
       admin: false,
     }
   }
-  let(:valid_attributes_admin) {
-    {
-      name: "Pete Conrad",
-      email: "pconrad@nasa.gov",
-      admin: true,
-    }
-  }
 
   let(:invalid_attributes) { {email: nil} }
 


### PR DESCRIPTION
We don't ever want the last admin to be deleted. So if an admin user tries to delete the last admin account, we don't allow it. A flash message prompts them to assign admin status to another user if they would like to proceed.