### PR TITLE
Fix the "missing NestedWishlistContext" bug

### DIFF
--- a/app/policies/amazon_search_policy.rb
+++ b/app/policies/amazon_search_policy.rb
@@ -1,3 +1,5 @@
+require 'nested_wishlist_context'
+
 class AmazonSearchPolicy
   def initialize(context, amazon_search)
     @user = context.user


### PR DESCRIPTION
Since I removed this from the `amazon_search_policy.rb` file, we need to explicitly include it for the tests.