### PR TITLE
Set Priority and Quantity for WishlistItems (Resolves #86)

### DIFF
--- a/app/controllers/wishlist_items_controller.rb
+++ b/app/controllers/wishlist_items_controller.rb
@@ -23,7 +23,8 @@ class WishlistItemsController < ApplicationController
     @wishlist_item = @wishlist.wishlist_items.create!(
       item: item,
       quantity: params[:qty],
-      staff_message: params[:staff_message])
+      staff_message: params[:staff_message],
+      priority: params[:priority])
 
     redirect_to wishlist_path(@wishlist), notice: "Added #{item.name}"
   end

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -27,7 +27,7 @@
         <%= text_field_tag "staff_message" %>
       </td>
       <td>
-        <%= select_tag "qty", options_for_select(Array(1..20), 1) %>
+        <%= select_tag "qty", options_for_select(Array(0..20), 1) %>
       </td>
       <td>
         <%= select_tag "priority", options_for_select(WishlistItem.priorities.keys) %>

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -27,7 +27,7 @@
         <%= text_field_tag "staff_message" %>
       </td>
       <td>
-        <%= select_tag "qty", options_for_select(Array(0..20)) %>
+        <%= select_tag "qty", options_for_select(Array(1..20), 1) %>
       </td>
       <td>
         <%= select_tag "priority", options_for_select(WishlistItem.priorities.keys) %>


### PR DESCRIPTION
- WishlistItems can now have their priority set at creation to "low," "medium," or "high."
- The default quantity for WishlistItems is 1, and may be any number between 1 and 20. Zero is no longer presented as a possible user input.