### PR TITLE
Pledges have a quantity

### DIFF
--- a/app/models/pledge.rb
+++ b/app/models/pledge.rb
@@ -7,6 +7,7 @@
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #  wishlist_item_id :integer
+#  quantity         :integer          default(1), not null
 #
 
 require "active_record_csv_generator"
@@ -14,6 +15,9 @@ require "active_record_csv_generator"
 class Pledge < ApplicationRecord
   belongs_to :wishlist_item
   belongs_to :user
+
+  validates :quantity, presence: true,
+                       numericality: { greater_than_or_equal_to: 1 }
 
   def self.generate_csv(csv_generator: ActiveRecordCSVGenerator.new(self))
     csv_generator.generate

--- a/db/migrate/20170817133935_add_quantity_to_pledges.rb
+++ b/db/migrate/20170817133935_add_quantity_to_pledges.rb
@@ -1,0 +1,5 @@
+class AddQuantityToPledges < ActiveRecord::Migration[5.1]
+  def change
+    add_column :pledges, :quantity, :integer, null: false, default: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170702132602) do
+ActiveRecord::Schema.define(version: 20170817133935) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,6 +33,7 @@ ActiveRecord::Schema.define(version: 20170702132602) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "wishlist_item_id"
+    t.integer "quantity", default: 1, null: false
     t.index ["user_id"], name: "index_pledges_on_user_id"
     t.index ["wishlist_item_id"], name: "index_pledges_on_wishlist_item_id"
   end

--- a/spec/factories/pledges.rb
+++ b/spec/factories/pledges.rb
@@ -7,6 +7,7 @@
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #  wishlist_item_id :integer
+#  quantity         :integer          default(1), not null
 #
 
 FactoryGirl.define do

--- a/spec/models/pledge_spec.rb
+++ b/spec/models/pledge_spec.rb
@@ -7,6 +7,7 @@
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #  wishlist_item_id :integer
+#  quantity         :integer          default(1), not null
 #
 
 require "rails_helper"
@@ -19,6 +20,16 @@ describe Pledge do
 
   describe "without an associated user" do
     subject { build(:pledge, user: nil) }
+    it { should_not be_valid }
+  end
+
+  describe "without a quantity" do
+    subject { build(:pledge, quantity: nil) }
+    it { should_not be_valid }
+  end
+
+  describe "with a quantity of 0" do
+    subject { build(:pledge, quantity: 0) }
     it { should_not be_valid }
   end
 


### PR DESCRIPTION
Resolves #91

This was a quick task, so I thought I'd take care of it now. Add a `quantity` attribute to pledges. 

Pledge quantity must be:

- Present
- Greater than or equal to 1

Database constraints make this column non-nullable and default to 1 as a backup.