### PR TITLE
Refactor controllers

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,7 +10,6 @@ class UsersController < ApplicationController
   end
 
   def show
-    @pledges = @user.pledges
     authorize @user
   end
 
@@ -21,6 +20,7 @@ class UsersController < ApplicationController
   def update
     authorize @user
 
+    # if the user's an admin, let them assign site managers
     if current_user.admin? && wishlist_ids = params[:user][:wishlist_ids]
       @user.wishlist_ids = wishlist_ids
     end

--- a/app/controllers/wishlist_items_controller.rb
+++ b/app/controllers/wishlist_items_controller.rb
@@ -7,26 +7,11 @@ class WishlistItemsController < ApplicationController
   end
 
   def create
-    @wishlist = Wishlist.find(params[:wishlist_id])
-    authorize @wishlist.wishlist_items.build
+    wishlist = Wishlist.find(params[:wishlist_id])
+    authorize wishlist.wishlist_items.build
 
-    item =
-      Item.find_by_asin(params[:asin]) ||
-      Item.create!(
-        asin: params[:asin],
-        amazon_url: params[:amazon_url],
-        price_cents: params[:price_cents],
-        image_url: params[:image_url],
-        image_width: params[:image_width],
-        image_height: params[:image_height],
-        name: params[:name])
-    @wishlist_item = @wishlist.wishlist_items.create!(
-      item: item,
-      quantity: params[:qty],
-      staff_message: params[:staff_message],
-      priority: params[:priority])
-
-    redirect_to wishlist_path(@wishlist), notice: "Added #{item.name}"
+    @wishlist_item = wishlist.wishlist_items.create!(wishlist_item_create_params)
+    redirect_to wishlist_path(@wishlist_item.wishlist), notice: "Added #{@wishlist_item.name}."
   end
 
   def edit
@@ -60,5 +45,22 @@ class WishlistItemsController < ApplicationController
     # Never trust parameters from the scary internet, only allow the white list through.
     def wishlist_item_params
       params.require(:wishlist_item).permit(:quantity, :priority, :staff_message)
+    end
+
+    def wishlist_item_create_params
+      amazon_item = Item.find_or_create_by_asin!(amazon_item_params)
+      wishlist_item_params.merge(item: amazon_item)
+    end
+
+    def amazon_item_params
+      {
+        asin:         params[:asin],
+        amazon_url:   params[:amazon_url],
+        price_cents:  params[:price_cents],
+        image_url:    params[:image_url],
+        image_width:  params[:image_width],
+        image_height: params[:image_height],
+        name:         params[:name],
+      }
     end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -20,4 +20,9 @@ class Item < ApplicationRecord
   has_many :wishlists, through: :wishlist_items
 
   validates :name, presence: true
+
+  def self.find_or_create_by_asin!(item_params)
+    asin = item_params[:asin] || item_params['asin']
+    Item.find_by_asin(asin) || Item.create!(item_params)
+  end
 end

--- a/app/views/amazon_search/show.html.erb
+++ b/app/views/amazon_search/show.html.erb
@@ -19,9 +19,7 @@
 
   <table class="table" id="search-results">
     <tbody>
-      <% @response.items.each do |item| %>
-        <%= render 'items/item', item: item %>
-      <% end  %>
+      <%= render partial: 'items/item', collection: @response.items %>
     </tbody>
   </table>
 </div>

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -1,6 +1,6 @@
 <% if item.valid? %>
   <tr class="item">
-    <%= form_tag wishlist_wishlist_items_path(wishlist: @wishlist) do %>
+    <%= form_for @wishlist.wishlist_items.build, url: wishlist_wishlist_items_path(@wishlist) do |f| %>
       <%= hidden_field_tag 'name', item.title %>
       <%= hidden_field_tag 'amazon_url', item.detail_page_url %>
       <%= hidden_field_tag 'price_cents', item.price_cents %>
@@ -24,17 +24,17 @@
       </td>
 
       <td>
-        <%= text_field_tag "staff_message", class: "form-control text-field-md" %>
+        <%= f.text_field :staff_message, class: "form-control text-field-md" %>
       </td>
       <td>
-        <%= select_tag "qty", options_for_select(Array(0..20), 1) %>
+        <%= f.select :quantity, options_for_select(Array(0..20), 1) %>
       </td>
       <td>
-        <%= select_tag "priority", options_for_select(WishlistItem.priorities.keys) %>
+        <%= f.select :priority, options_for_select(WishlistItem.priorities.keys) %>
       </td>
 
       <td>
-        <%= submit_tag "Add" %>
+        <%= f.submit "Add", class: "btn btn-primary btn-sm" %>
       </td>
     <% end %>
   </tr>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -43,7 +43,7 @@
   <br>
 
   <div id="pledges">
-    <% @pledges.each do |pledge| %>
+    <% @user.pledges.each do |pledge| %>
       <div class="pledge">
         <hr>
         <img class="card-img-left" src="<%= pledge.wishlist_item.item.image_url %>">

--- a/spec/features/managing_items_and_wishlists_spec.rb
+++ b/spec/features/managing_items_and_wishlists_spec.rb
@@ -23,8 +23,8 @@ feature "Managing items and wishlists:" do
       # add new item
       within("#search-results") do
         within(find_all(".item").first) do
-          fill_in("staff_message", with: "More corgi things!")
-          select("18", from: "qty")
+          fill_in("wishlist_item_staff_message", with: "More corgi things!")
+          select("18", from: "wishlist_item_quantity")
           click_button "Add"
         end
       end
@@ -188,8 +188,8 @@ feature "Managing items and wishlists:" do
       # add new item
       within("#search-results") do
         within(find_all(".item").first) do
-          fill_in("staff_message", with: "More corgi things!")
-          select("18", from: "qty")
+          fill_in("wishlist_item_staff_message", with: "More corgi things!")
+          select("18", from: "wishlist_item_quantity")
           click_button "Add"
         end
       end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -22,4 +22,36 @@ describe Item do
     subject { build(:item, name: nil) }
     it { should_not be_valid }
   end
+
+  describe ".find_or_create_by_asin!" do
+    let(:item_params) { attributes_for(:item, asin: "exists") }
+
+    context "when an item with that asin exists" do
+      before { create(:item, asin: "exists") }
+
+      it "should NOT create a new item" do
+        expect {
+          Item.find_or_create_by_asin!(item_params)
+        }.not_to change(Item, :count)
+      end
+
+      it "should return an Item with the given asin" do
+        item = Item.find_or_create_by_asin!(item_params)
+        expect(item.asin).to eq "exists"
+      end
+    end
+
+    context "when no object with that asin exists" do
+      it "should NOT create a new item" do
+        expect {
+          Item.find_or_create_by_asin!(item_params)
+        }.to change(Item, :count).by(1)
+      end
+
+      it "should return an Item with the given asin" do
+        item = Item.find_or_create_by_asin!(item_params)
+        expect(item.asin).to eq "exists"
+      end
+    end
+  end
 end


### PR DESCRIPTION
This isn't a mission-critical PR, but it fixes some things that have been bugging me.

The main goal of this commit is to remove cruft from controllers to make them easier to read/maintain.

### Major changes

  - Remove unneeded ivars
  - Item can handle its own `find_or_create_by_asin` logic
  - Set parameter lists in private methods (vs. in `#create` body, for example)
  - Make wishlist item creation form(s) model-based*

### Justifications

This last one might be controversial because this form creates two objects (potentially)-an `Item` and a `WishlistItem`-but only the latter are given primary status.

I think that a form object is a good idea for the future, but for now, `WishlistItem` is the main point of this form, and `form_for` lets us be more succinct in the controller.

`AcceptsNestedAttributesFor` is a mess in terms of error messages, so I'd like to avoid that.

*Let me know if you have any question/comments/concerns/disagreements!*