### PR TITLE
social share fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem 'omniauth-amazon'
 # Makes http fun again! http://jnunemaker.github.com/httparty
 gem 'httparty'
 # Helper for add social share feature in your Rails app. Twitter, Facebook, Weibo, Douban
-gem 'social-share-button'
+gem 'social-share-button', '~> 1.0.0'
 # most important gem for awesome debugging and awesome consoles
 gem 'pry-rails'
 # Authorizaton library

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,9 +62,9 @@ GEM
     childprocess (0.7.0)
       ffi (~> 1.0, >= 1.0.11)
     coderay (1.1.1)
-    coffee-rails (4.2.1)
+    coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
-      railties (>= 4.0.0, < 5.2.x)
+      railties (>= 4.0.0)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
@@ -217,7 +217,7 @@ GEM
       rubyzip (~> 1.0)
       websocket (~> 1.0)
     slop (3.6.0)
-    social-share-button (0.10.0)
+    social-share-button (1.0.0)
       coffee-rails
     spring (2.0.1)
       activesupport (>= 4.2)
@@ -286,7 +286,7 @@ DEPENDENCIES
   rspec-rails (~> 3.5)
   sass-rails (~> 5.0)
   selenium-webdriver
-  social-share-button
+  social-share-button (~> 1.0.0)
   spring
   spring-commands-rspec (~> 1.0)
   spring-watcher-listen (~> 2.0.0)
@@ -300,4 +300,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.15.3
+   1.15.4

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,8 +11,8 @@
 // about supported directives.
 //
 //= require jquery
-//= require bootstrap-sprockets
 //= require rails-ujs
+//= require bootstrap-sprockets
 //= require turbolinks
 //= require social-share-button
 //= require_tree .

--- a/config/initializers/social_share_button.rb
+++ b/config/initializers/social_share_button.rb
@@ -1,3 +1,3 @@
 SocialShareButton.configure do |config|
-  config.allow_sites = %w(facebook twitter email)
+  config.allow_sites = %w(twitter email)
 end


### PR DESCRIPTION
Updated to newest version of Social-share for Facebook fix https://github.com/huacnlee/social-share-button/pull/143/files, however Facebook tests the links before sharing them so localhost will always fail but it should work in release/prod.

Moved the order of dependencies, It appears bootstrap was loading before jquery which could be the root cause of the error we are seeing in staging. 

Unfortunately these changes need to be tested in staging/cannot be adequately tested in localhost