### PR TITLE
Guests should be able to pledge items

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,6 +73,8 @@ group :development do
   gem 'spring-watcher-listen', '~> 2.0.0'
   # Implements the `rspec` command for Spring, allowing for faster test loading
   gem 'spring-commands-rspec', '~> 1.0'
+  # Helps detect N+1 queries and unused eager loading
+  gem 'bullet'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,9 @@ GEM
       autoprefixer-rails (>= 6.0.3)
       sass (>= 3.4.19)
     builder (3.2.3)
+    bullet (5.6.1)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.10.0)
     byebug (9.0.6)
     capybara (2.14.0)
       addressable
@@ -245,6 +248,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
+    uniform_notifier (1.10.0)
     web-console (3.5.1)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -267,6 +271,7 @@ PLATFORMS
 DEPENDENCIES
   annotate (~> 2.7)
   bootstrap (~> 4.0.0.alpha6)
+  bullet
   byebug
   capybara (~> 2.13)
   database_cleaner (~> 1.6.1)

--- a/app/controllers/pledges_controller.rb
+++ b/app/controllers/pledges_controller.rb
@@ -4,8 +4,10 @@ class PledgesController < ApplicationController
   def index
     authorize Pledge
     respond_to do |format|
-      format.html { @pledges = Pledge.all }
       format.csv  { export_csv }
+      format.html do
+        @pledges = Pledge.includes(:user, wishlist_item: [:item, :wishlist])
+      end
     end
   end
 

--- a/app/controllers/pledges_controller.rb
+++ b/app/controllers/pledges_controller.rb
@@ -40,9 +40,10 @@ class PledgesController < ApplicationController
 
   def destroy
     authorize @pledge
-    pledging_user = @pledge.user
+    redirect_path = @pledge.anonymous? ? root_path : user_path(@pledge.user)
     @pledge.destroy
-    redirect_to user_path(pledging_user), notice: 'Pledge was successfully destroyed.'
+
+    redirect_to redirect_path, notice: 'Pledge was successfully destroyed.'
   end
 
   private

--- a/app/controllers/pledges_controller.rb
+++ b/app/controllers/pledges_controller.rb
@@ -43,7 +43,8 @@ class PledgesController < ApplicationController
   def claim
     @pledge = Pledge.find(params[:pledge_id])
     authorize @pledge
-    if @pledge.update(user_id: current_user.id)
+
+    if @pledge.claim_or_increment(user_id: current_user.id)
       redirect_to @pledge, notice: 'You have claimed this pledge.'
     else
       render :edit

--- a/app/controllers/pledges_controller.rb
+++ b/app/controllers/pledges_controller.rb
@@ -40,6 +40,16 @@ class PledgesController < ApplicationController
     end
   end
 
+  def claim
+    @pledge = Pledge.find(params[:pledge_id])
+    authorize @pledge
+    if @pledge.update(user_id: current_user.id)
+      redirect_to @pledge, notice: 'You have claimed this pledge.'
+    else
+      render :edit
+    end
+  end
+
   def destroy
     authorize @pledge
     redirect_path = @pledge.anonymous? ? root_path : user_path(@pledge.user)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,6 +10,8 @@ class UsersController < ApplicationController
   end
 
   def show
+    @user = User.includes(pledges: [wishlist_item: [:item, :wishlist]])
+                .find(params[:id])
     authorize @user
   end
 

--- a/app/controllers/wishlist_items_controller.rb
+++ b/app/controllers/wishlist_items_controller.rb
@@ -3,7 +3,7 @@ class WishlistItemsController < ApplicationController
 
   def index
     skip_authorization
-    @wishlist_items = WishlistItem.all
+    @wishlist_items = WishlistItem.includes(:item, :wishlist)
   end
 
   def create

--- a/app/controllers/wishlists_controller.rb
+++ b/app/controllers/wishlists_controller.rb
@@ -1,8 +1,9 @@
 class WishlistsController < ApplicationController
-  before_action :set_wishlist, only: [:show, :edit, :update, :destroy]
+  before_action :set_wishlist, only: [:edit, :update, :destroy]
 
   def show
     skip_authorization
+    @wishlist = Wishlist.includes(wishlist_items: :item).find(params[:id])
     @site_managers = @wishlist.users
     @wishlist_items = @wishlist.wishlist_items
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,6 +15,6 @@ module ApplicationHelper
 
   def current_user_pronouns(user, perspectives, capitalize: true)
     perspectives.map!(&:capitalize) if capitalize
-    pronoun = (user == current_user) ? perspectives[0] : perspectives[1]
+    pronoun = (user.nil? || user == current_user) ? perspectives[0] : perspectives[1]
   end
 end

--- a/app/models/pledge.rb
+++ b/app/models/pledge.rb
@@ -14,7 +14,7 @@ require "active_record_csv_generator"
 
 class Pledge < ApplicationRecord
   belongs_to :wishlist_item
-  belongs_to :user
+  belongs_to :user, optional: true
 
   delegate :wishlist, :item,        to: :wishlist_item
   delegate :image_url, :amazon_url, to: :item
@@ -24,7 +24,11 @@ class Pledge < ApplicationRecord
 
   validates :quantity, presence: true,
                        numericality: { greater_than_or_equal_to: 1 }
-  validates :wishlist_item, uniqueness: { scope: :user }
+  validates :wishlist_item, uniqueness: { scope: :user }, unless: :anonymous?
+
+  def anonymous?
+    !user_id
+  end
 
   def edited?
     created_at != updated_at

--- a/app/models/pledge.rb
+++ b/app/models/pledge.rb
@@ -21,7 +21,6 @@ class Pledge < ApplicationRecord
 
   delegate :name, to: :wishlist, prefix: true
   delegate :name, to: :item,     prefix: true
-  delegate :display_name, to: :user, prefix: true
 
   validates :quantity, presence: true,
                        numericality: { greater_than_or_equal_to: 1 }
@@ -33,6 +32,10 @@ class Pledge < ApplicationRecord
 
   def edited?
     created_at != updated_at
+  end
+
+  def user_display_name
+    anonymous? ? 'Anonymous' : user.display_name
   end
 
   class << self

--- a/app/models/pledge.rb
+++ b/app/models/pledge.rb
@@ -21,6 +21,7 @@ class Pledge < ApplicationRecord
 
   delegate :name, to: :wishlist, prefix: true
   delegate :name, to: :item,     prefix: true
+  delegate :display_name, to: :user, prefix: true
 
   validates :quantity, presence: true,
                        numericality: { greater_than_or_equal_to: 1 }

--- a/app/policies/pledge_policy.rb
+++ b/app/policies/pledge_policy.rb
@@ -20,6 +20,10 @@ class PledgePolicy < ApplicationPolicy
     user.admin? || user.pledged?(pledge) || pledge.anonymous?
   end
 
+  def claim?
+    pledge.anonymous? && user.logged_in?
+  end
+
   def destroy?
     user.admin? || user.pledged?(pledge) || pledge.anonymous?
   end

--- a/app/policies/pledge_policy.rb
+++ b/app/policies/pledge_policy.rb
@@ -9,7 +9,7 @@ class PledgePolicy < ApplicationPolicy
   end
 
   def show?
-    user.admin? || user.pledged?(pledge)
+    user.admin? || user.pledged?(pledge) || pledge.anonymous?
   end
 
   def create?

--- a/app/policies/pledge_policy.rb
+++ b/app/policies/pledge_policy.rb
@@ -21,7 +21,7 @@ class PledgePolicy < ApplicationPolicy
   end
 
   def destroy?
-    user.admin? || user.pledged?(pledge)
+    user.admin? || user.pledged?(pledge) || pledge.anonymous?
   end
 
   private

--- a/app/policies/pledge_policy.rb
+++ b/app/policies/pledge_policy.rb
@@ -17,7 +17,7 @@ class PledgePolicy < ApplicationPolicy
   end
 
   def update?
-    user.admin? || user.pledged?(pledge)
+    user.admin? || user.pledged?(pledge) || pledge.anonymous?
   end
 
   def destroy?

--- a/app/views/pledges/_form.html.erb
+++ b/app/views/pledges/_form.html.erb
@@ -20,8 +20,11 @@
 
     <dt class="col-sm-2">Pledging user</dt>
     <dd class="col-sm-10">
-      <%= link_to pledge.user.display_name, pledge.user %>
-      <%= "(You!)" if current_user == pledge.user %>
+      <% if pledge.anonymous? %>
+        Anonymous
+      <% else %>
+        <%= link_to pledge.user_display_name, pledge.user %>
+      <% end %>
     </dd>
 
     <dt class="col-sm-2"><%= form.label :quantity %></dt>

--- a/app/views/pledges/index.html.erb
+++ b/app/views/pledges/index.html.erb
@@ -18,7 +18,7 @@
         <tr class="pledge">
           <td><%= pledge.wishlist_item.name %></td>
           <td><%= link_to pledge.wishlist.name, pledge.wishlist %></td>
-          <td><%= link_to pledge.user.display_name, pledge.user %></td>
+          <td><%= link_to pledge.user_display_name, pledge.user %></td>
           <td><%= pledge.quantity %></td>
           <td><%= link_to 'Show', pledge %></td>
           <td><%= link_to 'Edit', edit_pledge_path(pledge) %></td>

--- a/app/views/pledges/show.html.erb
+++ b/app/views/pledges/show.html.erb
@@ -43,11 +43,11 @@
     </div>
   </div>
 
-  <p>
-    Manage <%= posessive_pronoun(@pledge.user, capitalize: false) %> pledge here
-    or on <%= posessive_pronoun(@pledge.user, capitalize: false) %>
-    <%= link_to 'user page', @pledge.user %>.
-  </p>
+  <% if current_user.pledged? @pledge %>
+    <p>
+      Manage your pledge here or on your <%= link_to 'user page', @pledge.user %>.
+    </p>
+  <% end %>
 
   <%= link_to "Back to #{@pledge.wishlist.name}", @pledge.wishlist %> |
   <%= link_to "Back to user page", @pledge.user %>

--- a/app/views/pledges/show.html.erb
+++ b/app/views/pledges/show.html.erb
@@ -20,6 +20,18 @@
 
   <br /><br />
 
+  <% if @pledge.anonymous? && current_user.logged_in? %>
+    <div class="row align-items-center unpledge">
+      <div class="col">
+        <h4>Did you make this pledge?
+        <%= link_to 'Claim pledge', pledge_claim_path(@pledge),
+          method: :patch,
+          class: 'btn btn-primary btn-sm text-right' %>
+        </h4>
+      </div>
+    </div>
+  <% end %>
+
   <div class="row align-items-center unpledge">
     <div class="col">
       <h4>Didn't mean to pledge?

--- a/app/views/pledges/show.html.erb
+++ b/app/views/pledges/show.html.erb
@@ -4,7 +4,17 @@
     "<%= @pledge.wishlist_item.name %>"
   </h2>
 
-  <p class="lead">Thanks for being a Hero of Play! On behalf of the children and families we serve, thank you! ♥</p>
+  <p class="lead">
+    <% if @pledge.anonymous? %>
+      Thank you for being a Hero of Play! ♥
+  </p>
+  <p class="lead">
+      But wait, we don't know who you are! By logging in, you make it much
+      easier for us to track donations. Sign up/log in with Amazon <%= link_to "here", signin_path %>.
+    <% else %>
+      Thanks for being a Hero of Play! On behalf of the children and families we serve, thank you! ♥
+    <% end %>
+  </p>
 
   <%= render @pledge %>
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -51,4 +51,25 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.alert = true
+    Bullet.bullet_logger = true
+    Bullet.console = true
+    # Bullet.growl = true
+    # Bullet.xmpp = { :account  => 'bullets_account@jabber.org',
+    #                 :password => 'bullets_password_for_jabber',
+    #                 :receiver => 'your_account@jabber.org',
+    #                 :show_online_status => true }
+    Bullet.rails_logger = true
+    # Bullet.honeybadger = true
+    # Bullet.bugsnag = true
+    # Bullet.airbrake = true
+    Bullet.rollbar = true
+    Bullet.add_footer = true
+    # Bullet.stacktrace_includes = [ 'your_gem', 'your_middleware' ]
+    # Bullet.stacktrace_excludes = [ 'their_gem', 'their_middleware' ]
+    # Bullet.slack = { webhook_url: 'http://some.slack.url', channel: '#default', username: 'notifier' }
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   # Pledges
-  resources :pledges, except: [:new]
+  resources :pledges, except: [:new] do
+    patch :claim
+  end
 
   # Wishlists & Items
   resources :wishlists, except: [:index] do

--- a/spec/controllers/pledges_controller_spec.rb
+++ b/spec/controllers/pledges_controller_spec.rb
@@ -22,7 +22,7 @@ describe PledgesController, type: :controller do
   describe "GET #index" do
     context "as a normal user" do
       it "DOES NOT return a success response" do
-        pledge = create(:pledge)
+        pledge = create(:pledge, :with_user)
         get :index, params: {}, session: user_session
         expect(response).not_to be_success
       end
@@ -30,7 +30,7 @@ describe PledgesController, type: :controller do
 
     context "as an admin" do
       it "returns a success response" do
-        pledge = create(:pledge)
+        pledge = create(:pledge, :with_user)
         get :index, params: {}, session: admin_session
         expect(response).to be_success
       end
@@ -41,12 +41,12 @@ describe PledgesController, type: :controller do
   describe "GET #show" do
     context "as a normal user" do
       it "DOES NOT return a success response" do
-        pledge = create(:pledge)
+        pledge = create(:pledge, :with_user)
         get :show, params: {id: pledge.id}, session: user_session
         expect(response).not_to be_success
       end
       it "redirects to the root url" do
-        pledge = create(:pledge)
+        pledge = create(:pledge, :with_user)
         get :show, params: {id: pledge.id}, session: user_session
         expect(response).to redirect_to(root_url)
       end
@@ -62,7 +62,7 @@ describe PledgesController, type: :controller do
 
     context "as an admin" do
       it "returns a success response" do
-        pledge = create(:pledge)
+        pledge = create(:pledge, :with_user)
         get :show, params: {id: pledge.id}, session: admin_session
         expect(response).to be_success
       end
@@ -73,12 +73,12 @@ describe PledgesController, type: :controller do
   describe "GET #edit" do
     context "as a normal user" do
       it "DOES NOT return a success response" do
-        pledge = create(:pledge)
+        pledge = create(:pledge, :with_user)
         get :edit, params: {id: pledge.id}, session: user_session
         expect(response).not_to be_success
       end
       it "redirects to the root url" do
-        pledge = create(:pledge)
+        pledge = create(:pledge, :with_user)
         get :edit, params: {id: pledge.id}, session: user_session
         expect(response).to redirect_to(root_url)
       end
@@ -94,7 +94,7 @@ describe PledgesController, type: :controller do
 
     context "as an admin" do
       it "returns a success response" do
-        pledge = create(:pledge)
+        pledge = create(:pledge, :with_user)
         get :edit, params: {id: pledge.id}, session: admin_session
         expect(response).to be_success
       end
@@ -107,7 +107,7 @@ describe PledgesController, type: :controller do
       let(:new_attributes) { {quantity: 2} }
 
       it "DOES NOT update the requested pledge" do
-        pledge = create(:pledge, quantity: 1)
+        pledge = create(:pledge, :with_user, quantity: 1)
         put :update, params: {id: pledge.id, pledge: new_attributes},
                      session: user_session
         pledge.reload
@@ -150,7 +150,7 @@ describe PledgesController, type: :controller do
         let(:new_attributes) { {quantity: 2} }
 
         it "updates the requested pledge" do
-          pledge = create(:pledge, quantity: 1)
+          pledge = create(:pledge, :with_user, quantity: 1)
           put :update, params: {id: pledge.id, pledge: new_attributes},
                        session: admin_session
           pledge.reload
@@ -158,7 +158,7 @@ describe PledgesController, type: :controller do
         end
 
         it "redirects to the pledge" do
-          pledge = create(:pledge)
+          pledge = create(:pledge, :with_user)
           put :update, params: {id: pledge.id, pledge: new_attributes},
                        session: admin_session
           expect(response).to redirect_to(pledge)
@@ -167,7 +167,7 @@ describe PledgesController, type: :controller do
 
       context "with invalid params" do
         it "returns a success response (i.e. to display the 'edit' template)" do
-          pledge = create(:pledge)
+          pledge = create(:pledge, :with_user)
           put :update, params: {id: pledge.id, pledge: invalid_attributes},
                       session: admin_session
           expect(response).to be_success
@@ -227,7 +227,7 @@ describe PledgesController, type: :controller do
   describe "DELETE #destroy" do
     context "as a normal user" do
       it "DOES NOT destroy the requested pledge" do
-        pledge = create(:pledge)
+        pledge = create(:pledge, :with_user)
         expect {
           delete :destroy, params: {id: pledge.to_param}, session: user_session
         }.not_to change(Pledge, :count)
@@ -251,7 +251,7 @@ describe PledgesController, type: :controller do
 
     context "as an admin" do
       it "destroys the requested pledge" do
-        pledge = create(:pledge)
+        pledge = create(:pledge, :with_user)
         expect {
           delete :destroy, params: {id: pledge.to_param}, session: admin_session
         }.to change(Pledge, :count).by(-1)

--- a/spec/factories/pledges.rb
+++ b/spec/factories/pledges.rb
@@ -13,10 +13,9 @@
 FactoryGirl.define do
   factory :pledge do
     wishlist_item
-    user
 
-    factory :anonymous_pledge do
-      user nil
+    trait :with_user do
+      user
     end
   end
 end

--- a/spec/factories/pledges.rb
+++ b/spec/factories/pledges.rb
@@ -14,5 +14,9 @@ FactoryGirl.define do
   factory :pledge do
     wishlist_item
     user
+
+    factory :anonymous_pledge do
+      user nil
+    end
   end
 end

--- a/spec/features/pledging_an_item_spec.rb
+++ b/spec/features/pledging_an_item_spec.rb
@@ -13,6 +13,13 @@ feature "Pledging an item:" do
       expect(page).to have_text "You pledged to donate"
       # TODO: expect a new tab to open to Amazon
     end
+
+    scenario "I can unpledge an anonymous pledge" do
+      pledge = create(:anonymous_pledge)
+      visit pledge_path(pledge)
+      within(".pledge") { click_link "Unpledge" }
+      expect(page).to have_text "Pledge was successfully destroyed"
+    end
   end
 
   context "As a user" do

--- a/spec/features/pledging_an_item_spec.rb
+++ b/spec/features/pledging_an_item_spec.rb
@@ -6,10 +6,14 @@ feature "Pledging an item:" do
     create(:pledge, id: 100)
   end
 
-  # context "As a guest" do
-    # scenario "I can purchase a wish list item"
-    # scenario "I can confirm that an item was purchased"
-  # end
+  context "As a guest" do
+    scenario "I can pledge an item" do
+      visit root_path
+      click_button "Pledge to Donate"
+      expect(page).to have_text "You pledged to donate"
+      # TODO: expect a new tab to open to Amazon
+    end
+  end
 
   context "As a user" do
     before { login(as: :user) }

--- a/spec/features/pledging_an_item_spec.rb
+++ b/spec/features/pledging_an_item_spec.rb
@@ -42,6 +42,13 @@ feature "Pledging an item:" do
       expect(page).to have_text "You pledged to donate"
       # TODO: expect a new tab to open to Amazon
     end
+
+    scenario "I can claim an anonymous item" do
+      pledge = create(:anonymous_pledge)
+      visit pledge_path(pledge)
+      click_link "Claim pledge"
+      expect(page).to have_text "You have claimed this pledge"
+    end
   end
 
   context "As the pledging user" do
@@ -75,7 +82,11 @@ feature "Pledging an item:" do
       expect(page).to have_text "Number pledged 3"
     end
 
-    # scenario "I can re-pledge an item to increment its quantity" do
+    scenario "I can re-pledge an item to increment its quantity" do
+      visit wishlist_path(pledge.wishlist)
+      click_button "Pledge to Donate"
+      expect(page).to have_text "Number pledged 2"
+    end
   end
 
   context "As an admin" do

--- a/spec/features/pledging_an_item_spec.rb
+++ b/spec/features/pledging_an_item_spec.rb
@@ -20,6 +20,16 @@ feature "Pledging an item:" do
       within(".pledge") { click_link "Unpledge" }
       expect(page).to have_text "Pledge was successfully destroyed"
     end
+
+    scenario "I can update the quantity of an anonymous pledge" do
+      pledge = create(:anonymous_pledge)
+      visit edit_pledge_path(pledge)
+      fill_in "pledge_quantity", with: "3"
+      click_button "Update Pledge"
+
+      expect(page).to have_text "Pledge was successfully updated"
+      expect(page).to have_text "Number pledged 3"
+    end
   end
 
   context "As a user" do

--- a/spec/features/pledging_an_item_spec.rb
+++ b/spec/features/pledging_an_item_spec.rb
@@ -3,7 +3,7 @@ require "support/omniauth"
 
 feature "Pledging an item:" do
   before do
-    create(:pledge, id: 100)
+    create(:pledge, :with_user, id: 100)
   end
 
   context "As a guest" do
@@ -15,14 +15,14 @@ feature "Pledging an item:" do
     end
 
     scenario "I can unpledge an anonymous pledge" do
-      pledge = create(:anonymous_pledge)
+      pledge = create(:pledge, user: nil)
       visit pledge_path(pledge)
       within(".pledge") { click_link "Unpledge" }
       expect(page).to have_text "Pledge was successfully destroyed"
     end
 
     scenario "I can update the quantity of an anonymous pledge" do
-      pledge = create(:anonymous_pledge)
+      pledge = create(:pledge, user: nil)
       visit edit_pledge_path(pledge)
       fill_in "pledge_quantity", with: "3"
       click_button "Update Pledge"
@@ -44,7 +44,7 @@ feature "Pledging an item:" do
     end
 
     scenario "I can claim an anonymous item" do
-      pledge = create(:anonymous_pledge)
+      pledge = create(:pledge, user: nil)
       visit pledge_path(pledge)
       click_link "Claim pledge"
       expect(page).to have_text "You have claimed this pledge"

--- a/spec/features/pledging_an_item_spec.rb
+++ b/spec/features/pledging_an_item_spec.rb
@@ -49,6 +49,17 @@ feature "Pledging an item:" do
       click_link "Claim pledge"
       expect(page).to have_text "You have claimed this pledge"
     end
+
+    scenario "I can claim a duplicate anonymous item" do
+      current_user = User.last
+      wishlist_item = create(:wishlist_item)
+      create(:pledge, wishlist_item: wishlist_item, user: current_user)
+      pledge = create(:pledge, wishlist_item: wishlist_item)
+
+      visit pledge_path(pledge)
+      click_link "Claim pledge"
+      expect(page).to have_text "You have claimed this pledge"
+    end
   end
 
   context "As the pledging user" do

--- a/spec/models/pledge_spec.rb
+++ b/spec/models/pledge_spec.rb
@@ -93,6 +93,39 @@ describe Pledge do
     end
   end
 
+  describe "#claim_or_increment" do
+    context "when another pledge with those attributes exists" do
+      let(:user) { create(:user) }
+      let(:existing_pledge) { create(:pledge, user: user) }
+      let(:pledge) { create(:pledge, user: nil, wishlist_item: existing_pledge.wishlist_item) }
+
+      it "should belong to user" do
+        pledge.claim_or_increment(user_id: user.id)
+        expect(pledge.reload.user).to eq user
+      end
+
+      it "should delete the previous pledge" do
+        expect {
+          pledge.claim_or_increment(user_id: user.id)
+        }.to change(Pledge, :count).by(1)
+      end
+
+      it "should increment the quantity" do
+        pledge.claim_or_increment(user_id: user.id)
+        expect(pledge.reload.quantity).to eq 2
+      end
+    end
+
+    context "when it's a unique pledge" do
+      it "should belong to the user" do
+        user = create(:user)
+        pledge = create(:pledge, user: nil)
+        pledge.claim_or_increment(user_id: user.id)
+        expect(pledge.reload.user).to eq user
+      end
+    end
+  end
+
   describe ".generate_csv" do
     before { create(:pledge, id: 100) }
     subject(:csv) { Pledge.generate_csv }

--- a/spec/models/pledge_spec.rb
+++ b/spec/models/pledge_spec.rb
@@ -37,7 +37,7 @@ describe Pledge do
   end
 
   describe "uniqueness validation" do
-    let(:initial_pledge) { create(:pledge) }
+    let(:initial_pledge) { create(:pledge, :with_user) }
 
     context "when the user and wishlist are duplicated" do
       subject { build(:pledge, user: initial_pledge.user,
@@ -58,8 +58,8 @@ describe Pledge do
     context "when the user is nil" do
       it 'should allow for "duplicate" pledges' do
         wishlist_item = create(:wishlist_item)
-        create(:anonymous_pledge, wishlist_item: wishlist_item)
-        anon_pledge = build(:anonymous_pledge, wishlist_item: wishlist_item)
+        create(:pledge, user: nil, wishlist_item: wishlist_item)
+        anon_pledge = build(:pledge, wishlist_item: wishlist_item)
 
         expect(anon_pledge).to be_valid
       end
@@ -83,12 +83,12 @@ describe Pledge do
 
   describe "#anonymous?" do
     context "when it's owned by a user" do
-      subject { create(:pledge).anonymous? }
+      subject { create(:pledge, :with_user).anonymous? }
       it { should be false }
     end
 
     context "when it's not owned by a user" do
-      subject { create(:anonymous_pledge).anonymous? }
+      subject { create(:pledge, user: nil).anonymous? }
       it { should be true }
     end
   end

--- a/spec/models/pledge_spec.rb
+++ b/spec/models/pledge_spec.rb
@@ -23,7 +23,7 @@ describe Pledge do
 
   describe "without an associated user" do
     subject { build(:pledge, user: nil) }
-    it { should_not be_valid }
+    it { should be_valid }
   end
 
   describe "without a quantity" do
@@ -54,6 +54,16 @@ describe Pledge do
       subject { build(:pledge, wishlist_item: initial_pledge.wishlist_item) }
       it { should be_valid }
     end
+
+    context "when the user is nil" do
+      it 'should allow for "duplicate" pledges' do
+        wishlist_item = create(:wishlist_item)
+        create(:anonymous_pledge, wishlist_item: wishlist_item)
+        anon_pledge = build(:anonymous_pledge, wishlist_item: wishlist_item)
+
+        expect(anon_pledge).to be_valid
+      end
+    end
   end
 
   describe "#edited?" do
@@ -67,6 +77,18 @@ describe Pledge do
     context "when it has been updated" do
       before { pledge.update!(quantity: 2) }
       subject { pledge.edited? }
+      it { should be true }
+    end
+  end
+
+  describe "#anonymous?" do
+    context "when it's owned by a user" do
+      subject { create(:pledge).anonymous? }
+      it { should be false }
+    end
+
+    context "when it's not owned by a user" do
+      subject { create(:anonymous_pledge).anonymous? }
       it { should be true }
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -125,8 +125,8 @@ describe User do
   end
 
   describe "#pledge_for" do
-    let(:pledge) { create(:pledge) }
-    let(:user) { pledge.user }
+    let(:user) { create(:user) }
+    let(:pledge) { create(:pledge, user: user) }
 
     context "when the user pledged the item" do
       subject { user.pledge_for(pledge.wishlist_item) }

--- a/spec/policies/pledge_policy_spec.rb
+++ b/spec/policies/pledge_policy_spec.rb
@@ -59,7 +59,11 @@ describe PledgePolicy do
       expect(subject).not_to permit(GuestUser.new, build(:pledge))
     end
 
-    it "denies access to users" do
+    it "grants access to anyone (if anonymous)" do
+      expect(subject).to permit(GuestUser.new, create(:anonymous_pledge))
+    end
+
+    it "denies access to users (if owned)" do
       expect(subject).not_to permit(build(:user), build(:pledge))
     end
 

--- a/spec/policies/pledge_policy_spec.rb
+++ b/spec/policies/pledge_policy_spec.rb
@@ -18,25 +18,25 @@ describe PledgePolicy do
   end
 
   permissions :show? do
-    it "denies access to guests" do
-      expect(subject).not_to permit(GuestUser.new, create(:pledge))
+    it "grants access to anyone (if anonymous)" do
+      expect(subject).to permit(GuestUser.new, create(:pledge, user: nil))
     end
 
-    it "grants access to anyone (if anonymous)" do
-      expect(subject).to permit(GuestUser.new, create(:anonymous_pledge))
+    it "denies access to guests (if owned)" do
+      expect(subject).not_to permit(GuestUser.new, create(:pledge, :with_user))
     end
 
     it "denies access to unrelated users (if owned)" do
-      expect(subject).not_to permit(build(:user), create(:pledge))
+      expect(subject).not_to permit(build(:user), create(:pledge, :with_user))
     end
 
     it "grants access to the pledging user" do
-      pledge = create(:pledge)
+      pledge = create(:pledge, :with_user)
       expect(subject).to permit(pledge.user, pledge)
     end
 
     it "grants access to admins" do
-      expect(subject).to permit(build(:admin), create(:pledge))
+      expect(subject).to permit(build(:admin), create(:pledge, :with_user))
     end
   end
 
@@ -55,62 +55,62 @@ describe PledgePolicy do
   end
 
   permissions :update? do
-    it "denies access to guests" do
-      expect(subject).not_to permit(GuestUser.new, build(:pledge))
+    it "grants access to anyone (if anonymous)" do
+      expect(subject).to permit(GuestUser.new, build(:pledge, user: nil))
     end
 
-    it "grants access to anyone (if anonymous)" do
-      expect(subject).to permit(GuestUser.new, create(:anonymous_pledge))
+    it "denies access to guests (if owned)" do
+      expect(subject).not_to permit(GuestUser.new, build(:pledge, :with_user))
     end
 
     it "denies access to users (if owned)" do
-      expect(subject).not_to permit(build(:user), build(:pledge))
+      expect(subject).not_to permit(build(:user), build(:pledge, :with_user))
     end
 
     it "grants access to the pledging user" do
-      pledge = create(:pledge)
+      pledge = create(:pledge, :with_user)
       expect(subject).to permit(pledge.user, pledge)
     end
 
     it "grants access to admins" do
-      expect(subject).to permit(build(:admin), build(:pledge))
+      expect(subject).to permit(build(:admin), build(:pledge, :with_user))
     end
   end
 
   permissions :claim? do
     it "denies access to guests" do
-      expect(subject).not_to permit(GuestUser.new, build(:anonymous_pledge))
+      expect(subject).not_to permit(GuestUser.new, build(:pledge))
     end
 
     it "grants access to users (if anonymous)" do
-      expect(subject).to permit(build(:user), create(:anonymous_pledge))
+      expect(subject).to permit(build(:user), create(:pledge, user: nil))
     end
 
     it "denies access to users (if owned)" do
-      expect(subject).not_to permit(build(:user), build(:pledge))
+      expect(subject).not_to permit(build(:user), build(:pledge, :with_user))
     end
   end
 
   permissions :destroy? do
-    it "denies access to guests" do
-      expect(subject).not_to permit(GuestUser.new, build(:pledge))
+    it "denies access to guests (if owned)" do
+      expect(subject).not_to permit(GuestUser.new, build(:pledge, :with_user))
     end
 
     it "grants access to anyone (if anonymous)" do
-      expect(subject).to permit(GuestUser.new, create(:anonymous_pledge))
+      expect(subject).to permit(GuestUser.new, build(:pledge, user: nil))
     end
 
     it "denies access to unrelated users (if owned)" do
-      expect(subject).not_to permit(build(:user), build(:pledge))
+      expect(subject).not_to permit(build(:user), build(:pledge, :with_user))
     end
 
     it "grants access to the pledging user" do
-      pledge = create(:pledge)
+      pledge = create(:pledge, :with_user)
       expect(subject).to permit(pledge.user, pledge)
     end
 
     it "grants access to admins" do
-      expect(subject).to permit(build(:admin), build(:pledge))
+      expect(subject).to permit(build(:admin), build(:pledge, :with_user))
     end
   end
 end

--- a/spec/policies/pledge_policy_spec.rb
+++ b/spec/policies/pledge_policy_spec.rb
@@ -77,6 +77,20 @@ describe PledgePolicy do
     end
   end
 
+  permissions :claim? do
+    it "denies access to guests" do
+      expect(subject).not_to permit(GuestUser.new, build(:anonymous_pledge))
+    end
+
+    it "grants access to users (if anonymous)" do
+      expect(subject).to permit(build(:user), create(:anonymous_pledge))
+    end
+
+    it "denies access to users (if owned)" do
+      expect(subject).not_to permit(build(:user), build(:pledge))
+    end
+  end
+
   permissions :destroy? do
     it "denies access to guests" do
       expect(subject).not_to permit(GuestUser.new, build(:pledge))

--- a/spec/policies/pledge_policy_spec.rb
+++ b/spec/policies/pledge_policy_spec.rb
@@ -22,7 +22,11 @@ describe PledgePolicy do
       expect(subject).not_to permit(GuestUser.new, create(:pledge))
     end
 
-    it "denies access to unrelated users" do
+    it "grants access to anyone (if anonymous)" do
+      expect(subject).to permit(GuestUser.new, create(:anonymous_pledge))
+    end
+
+    it "denies access to unrelated users (if owned)" do
       expect(subject).not_to permit(build(:user), create(:pledge))
     end
 

--- a/spec/policies/pledge_policy_spec.rb
+++ b/spec/policies/pledge_policy_spec.rb
@@ -78,7 +78,11 @@ describe PledgePolicy do
       expect(subject).not_to permit(GuestUser.new, build(:pledge))
     end
 
-    it "denies access to unrelated users" do
+    it "grants access to anyone (if anonymous)" do
+      expect(subject).to permit(GuestUser.new, create(:anonymous_pledge))
+    end
+
+    it "denies access to unrelated users (if owned)" do
       expect(subject).not_to permit(build(:user), build(:pledge))
     end
 


### PR DESCRIPTION
Resolves #94, Resolves #77 

Woo, a whole new feature!

We made some decisions here to, namely:

* *anyone* can unpledge an anonymous pledge (if they have the url)
* *anyone* can edit the quantity of an anonymous pledge (if they have the url)
* *any user* can claim an anonymous pledge (if they have the url)

This is because you can't do too many nefarious deeds with anonymous pledges, and this lets the user claim/modify them later on, keeping Playtime updated.