### PR TITLE
Human-readable CSV

### DIFF
--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -1,2 +1,0 @@
-module ItemsHelper
-end

--- a/app/models/pledge.rb
+++ b/app/models/pledge.rb
@@ -37,9 +37,10 @@ class Pledge < ApplicationRecord
 
     def generate_csv(csv_generator: ActiveRecordCSVGenerator.new(self))
       csv_generator.generate(columns: [
-        ['pledged item',  ->(r) { r.item_name }],
-        ['wishlist',      ->(r) { r.wishlist_name }],
-        ['pledging user', ->(r) { r.user_display_name }],
+        ['pledged item',  ->(p) { p.item_name }],
+        ['wishlist',      ->(p) { p.wishlist_name }],
+        ['pledging user', ->(p) { p.user_display_name }],
+        ['email',         ->(p) { p.user_email }],
         :quantity,
         ['created at', ->(p) { p.created_at }],
         ['updated at', ->(p) { p.updated_at }],
@@ -63,9 +64,17 @@ class Pledge < ApplicationRecord
     created_at != updated_at
   end
 
+  def user_email
+    anonymous? ? nil : user.email
+  end
+
   def user_display_name
     anonymous? ? 'Anonymous' : user.display_name
   end
+  def user_email
+    anonymous? ? nil : user.email
+  end
+
 
   def claim_or_increment(user_id:)
     existing_pledge = Pledge.find_by(user_id: user_id,

--- a/app/models/pledge.rb
+++ b/app/models/pledge.rb
@@ -36,7 +36,14 @@ class Pledge < ApplicationRecord
     end
 
     def generate_csv(csv_generator: ActiveRecordCSVGenerator.new(self))
-      csv_generator.generate
+      csv_generator.generate(columns: [
+        ['pledged item',  ->(r) { r.item_name }],
+        ['wishlist',      ->(r) { r.wishlist_name }],
+        ['pledging user', ->(r) { r.user_display_name }],
+        :quantity,
+        ['created at', ->(p) { p.created_at }],
+        ['updated at', ->(p) { p.updated_at }],
+      ])
     end
 
     private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,8 +48,24 @@ class User < ApplicationRecord
     true
   end
 
+  def site_manager?
+    wishlists.exists?
+  end
+
+  def pledge_count
+    pledges.pluck(:quantity).sum
+  end
+
   def self.generate_csv(csv_generator: ActiveRecordCSVGenerator.new(self))
-    csv_generator.generate
+    csv_generator.generate(columns: [
+      :name,
+      :email,
+      :zipcode,
+      ['admin?', ->(u) { u.admin }],
+      ['site manager?', ->(u) { u.site_manager? }],
+      ['pledge count', ->(u) { u.pledge_count }],
+      ['created at', ->(u) { u.created_at }],
+    ])
   end
 
   def self.find_or_create_from_amazon_hash!(hash)

--- a/app/views/pledges/index.html.erb
+++ b/app/views/pledges/index.html.erb
@@ -18,7 +18,13 @@
         <tr class="pledge">
           <td><%= pledge.wishlist_item.name %></td>
           <td><%= link_to pledge.wishlist.name, pledge.wishlist %></td>
-          <td><%= link_to pledge.user_display_name, pledge.user %></td>
+          <td>
+            <% if pledge.anonymous? %>
+              Anonymous
+            <% else %>
+              <%=link_to pledge.user_display_name, pledge.user %>
+            <% end %>
+          </td>
           <td><%= pledge.quantity %></td>
           <td><%= link_to 'Show', pledge %></td>
           <td><%= link_to 'Edit', edit_pledge_path(pledge) %></td>

--- a/lib/active_record_csv_generator.rb
+++ b/lib/active_record_csv_generator.rb
@@ -5,10 +5,49 @@
 # controlled columns.
 #
 class ActiveRecordCSVGenerator
+  # Initializes a new csv generator for a given resource
+  #
+  # A resource is an ActiveRecord model or something that obeys the same
+  # interface. Column names can be specified in the `generate` method (so
+  # one generator can generate many different csv reports), but each generator
+  # focuses on a single resource.
+  #
+  # Example:
+  #
+  #     > user_generator = ActiveRecordCSVGenerator.new(User)
+  #
   def initialize(resource)
     @resource = resource
   end
 
+  # Generates a CSV given the target resource and list of columns.
+  #
+  # Columns can be either a string/symbolic attribute name (e.g. :created_at)
+  # or a tuple of a column name and value function.
+  #
+  # Example:
+  #
+  #     > user_generator.generate(columns: [
+  #       'name',
+  #       :email,
+  #       [:admin?,         ->(u) { u.admin? }],
+  #       ['site manager?', ->(u) { u.site_manager? }],
+  #       ['or whatever',   ->(_) { 'anything you want' }],
+  #     ])
+  #
+  #     name,email,admin?,site manager?,or whatever
+  #     Raj,user@example.com,true,false,anything you want
+  #     Betsy,user2@example.com,false,false,anything you want
+  #     ...
+  #
+  # CSV format is specified in the parameter list, which allows one generator
+  # to generate many different reports.
+  #
+  # Example:
+  #
+  #     > user_report_1 = user_generator.generate(columns: report_1_cols)
+  #     > user_report_2 = user_generator.generate(columns: report_2_cols)
+  #
   def generate(columns:)
     columns = evaluate_columns(columns)
 
@@ -26,13 +65,26 @@ class ActiveRecordCSVGenerator
 
   # Turn columns into a hash -> headers have column headers, fields have a
   # lambda with arity-1 that takes a record and returns field value.
+  #
+  # Example:
+  #
+  #     > evaluate_columns([:name, ['admin?', ->(r) { r.admin? }], :uid])
+  #     {
+  #       headers: ['name', 'admin?', 'uid'],
+  #       fields: [
+  #         ->(r) { r.attributes['name'] },
+  #         ->(r) { r.admin? },
+  #         ->(r) { r.attributes['uid'] },
+  #       ]
+  #     }
+  #
   def evaluate_columns(columns)
     columns.reduce({headers:[], fields:[]}) do |acc, column|
       if column.is_a? Array
-        acc[:headers] << column[0]
+        acc[:headers] << column[0].to_s
         acc[:fields]  << column[1]
       else
-        acc[:headers] << column
+        acc[:headers] << column.to_s
         acc[:fields]  << ->(record) { record.attributes[column.to_s] }
       end
       acc

--- a/spec/features/managing_users_spec.rb
+++ b/spec/features/managing_users_spec.rb
@@ -94,7 +94,7 @@ feature "Managing Users:" do
       click_link "Users"
       click_link "Export CSV"
 
-      expect(page).to have_text "id,"               # should be a csv...
+      expect(page).to have_text "name,email,"       # should be a csv...
       expect(page).to have_text "admin@example.com" # ...with user data
     end
 

--- a/spec/features/pledging_an_item_spec.rb
+++ b/spec/features/pledging_an_item_spec.rb
@@ -3,7 +3,7 @@ require "support/omniauth"
 
 feature "Pledging an item:" do
   before do
-    create(:pledge, :with_user, id: 100)
+    create(:pledge, user: create(:user, name: 'Bill Gates'))
   end
 
   context "As a guest" do
@@ -139,8 +139,8 @@ feature "Pledging an item:" do
       visit pledges_path
       click_link "Export CSV"
 
-      expect(page).to have_text "id," # should be a csv...
-      expect(page).to have_text "100" # ...with pledge data
+      expect(page).to have_text "user,"      # should be a csv...
+      expect(page).to have_text "Bill Gates" # ...with pledge data
     end
   end
 end

--- a/spec/lib/active_record_csv_generator_spec.rb
+++ b/spec/lib/active_record_csv_generator_spec.rb
@@ -3,25 +3,16 @@ require "active_record_csv_generator"
 describe ActiveRecordCSVGenerator do
   describe ".generate" do
     context "with a resource that adheres to the ActiveRecord interface" do
-      FakeUser = Struct.new(:name)
-      let(:ar_resource) do
-        db = { headers: ["id", "name", "user_id"],
-               values:  [   1, "DC General", "1"] }
-
-        # double of a wishlist instance
-        record = instance_double "Wishlist"
-        allow(record).to receive("attributes") do
-          db[:headers].zip(db[:values]).to_h
-        end
-        users = [FakeUser.new("Jason"), FakeUser.new("Polly")]
-        allow(record).to receive_message_chain("users") { users }
-
-        # double of the Wishlist model
-        double "Wishlist", column_names: db[:headers],
-                           all: [record]
+      # Set an initial db state of one wishlist with two site managers.
+      before do
+        create(:wishlist, name: 'DC General', id: 1, users: [
+          create(:user, name: 'Jason'),
+          create(:user, name: 'Polly')
+        ])
       end
+      let(:ar_resource) { Wishlist }
+      let(:generator)   { ActiveRecordCSVGenerator.new(ar_resource) }
 
-      let(:generator) { ActiveRecordCSVGenerator.new(ar_resource) }
 
       it "generates a csv" do
         csv = generator.generate(columns: [:id, :name])

--- a/spec/lib/active_record_csv_generator_spec.rb
+++ b/spec/lib/active_record_csv_generator_spec.rb
@@ -3,23 +3,48 @@ require "active_record_csv_generator"
 describe ActiveRecordCSVGenerator do
   describe ".generate" do
     context "with a resource that adheres to the ActiveRecord interface" do
+      FakeUser = Struct.new(:name)
       let(:ar_resource) do
-        db = { headers: ["id", "name"],
-               values:  [   1, "DC General"] }
+        db = { headers: ["id", "name", "user_id"],
+               values:  [   1, "DC General", "1"] }
 
         # double of a wishlist instance
         record = instance_double "Wishlist"
-        allow(record).to receive_message_chain("attributes.values") { db[:values] }
+        allow(record).to receive("attributes") do
+          db[:headers].zip(db[:values]).to_h
+        end
+        users = [FakeUser.new("Jason"), FakeUser.new("Polly")]
+        allow(record).to receive_message_chain("users") { users }
 
         # double of the Wishlist model
         double "Wishlist", column_names: db[:headers],
                            all: [record]
       end
 
-      subject(:csv) { ActiveRecordCSVGenerator.new(ar_resource).generate }
+      let(:generator) { ActiveRecordCSVGenerator.new(ar_resource) }
 
       it "generates a csv" do
+        csv = generator.generate(columns: [:id, :name])
         expect(csv).to eq "id,name\n1,DC General\n"
+      end
+
+      context "when a value is an association" do
+        it "should return the association value" do
+          site_managers_string = ->(record) { record.users.map(&:name).join(" ")}
+          csv = generator.generate(columns: [
+              :id,
+              :name,
+              [:site_managers, site_managers_string]
+          ])
+          expect(csv).to eq "id,name,site_managers\n1,DC General,Jason Polly\n"
+        end
+      end
+
+      context "when a value is an arbitrary lambda" do
+        it "should include key as the col name and result as value" do
+          csv = generator.generate(columns: [:name, [:age, ->(_) { 10 }]])
+          expect(csv).to eq "name,age\nDC General,10\n"
+        end
       end
     end
   end

--- a/spec/models/pledge_spec.rb
+++ b/spec/models/pledge_spec.rb
@@ -127,12 +127,12 @@ describe Pledge do
   end
 
   describe ".generate_csv" do
-    before { create(:pledge, id: 100) }
+    before { create(:pledge, user: create(:user, name: "Tony Stark")) }
     subject(:csv) { Pledge.generate_csv }
 
     it "should generate a csv" do
-      expect(csv).to include "id"
-      expect(csv).to include "100"
+      expect(csv).to include "user,"
+      expect(csv).to include "Tony Stark"
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -107,6 +107,15 @@ describe User do
     it { should be true }
   end
 
+  describe "#pledge_count" do
+    subject {
+      user = create(:user, pledges: [create(:pledge, user: nil, quantity: 2),
+                                     create(:pledge, user: nil)])
+      user.pledge_count
+    }
+    it { should eq 3 }
+  end
+
   describe "#made_pledge?" do
     let(:pledge) { create(:pledge) }
 
@@ -117,7 +126,7 @@ describe User do
 
     context "when the user didn't make the pledge" do
       subject {
-        other_pledge = create(:pledge)
+        other_pledge = create(:pledge, :with_user)
         build(:user, pledges: [other_pledge]).pledged?(pledge)
       }
       it { should be false }


### PR DESCRIPTION
Resolves #99 

The `ActiveRecordCSVGenerator` can now take custom, non-attribute-based columns and use custom column names. I've updated the User and Pledge csv configs to output helpful data.

**Don't merge this yet–it's dependent on #109 (anonymous pledges)**
*(I also want to refactor a gnarly text double in the generator specs and (hopefully) the private method in the generator class)*