### PR TITLE
Developer login

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -4,11 +4,15 @@ AMAZON_CLIENT_SECRET=YOURSECRETHERE
 AWS_ACCESS_KEY=YOUR_ACCESS_KEY_GOES_HERE
 AWS_SECRET_KEY=YOUR_SECRET_KEY_GOES_HERE
 AWS_ASSOCIATES_TAG=playtim009-20
+FORCE_AMAZON_LOGIN=false
 
-RACK_ENV=development  # defaults to development if blank
-PORT=3000             # defaults to 3000 if blank
+# defaults to development if blank
+RACK_ENV=development
+# defaults to 3000 if blank
+PORT=3000
 
 ADMIN_NAME=YOUR_NAME
-ADMIN_AMAZON_EMAIL=YOUR_EMAIL # The email associated with your amazon account.
-                              # This will let you log in as an admin using
-                              # Amazon authentication.
+# The email associated with your amazon account.
+# This will let you log in as an admin using
+# Amazon authentication.
+ADMIN_AMAZON_EMAIL=YOUR_EMAIL

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Navigate to your desired working directory. Then from a command prompt:
 
 Then navigate to `http://localhost:3000` in your browser to view the app.
 
-#### Getting Amazon OAuth Working Locally
+#### Getting Amazon OAuth Working Locally (Optional)
 
 By the end of this section, you should be able to create an account/login to
 the app on your local machine.
@@ -255,6 +255,10 @@ For changes to `.env` to take effect, you'll need to restart your server.
   # Advertisement API Working Locally"
   AWS_ACCESS_KEY="your aws access key"
   AWS_SECRET_KEY="your aws secret key"
+
+  # If you want to force Amazon login instead of developer in development environment
+  # set it to true.
+  FORCE_AMAZON_LOGIN=false
 
   # Code for generating affiliate links from search (same for everyone)
   AWS_ASSOCIATES_TAG="playtim009-20"

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,9 +1,12 @@
 class SessionsController < ApplicationController
   before_action :skip_authorization
+  skip_before_action :verify_authenticity_token, if: :should_skip_csrf_check?
 
   def new
     if current_user.logged_in?
       redirect_to '/'
+    elsif development_login_enabled?
+      redirect_to '/auth/developer'
     else
       redirect_to '/auth/amazon'
     end
@@ -31,5 +34,13 @@ class SessionsController < ApplicationController
   private
     def auth_hash
       request.env['omniauth.auth']
+    end
+
+    def should_skip_csrf_check?
+      Rails.env.development? && params[:provider] == 'developer'
+    end
+
+    def development_login_enabled?
+      Rails.env.development? && ENV['FORCE_AMAZON_LOGIN'] != 'true'
     end
 end

--- a/app/views/partials/_primary_nav.html.erb
+++ b/app/views/partials/_primary_nav.html.erb
@@ -59,6 +59,8 @@
         <li class="nav-item">
           <% if current_user.logged_in? %>
             <%= link_to "Log Out", signout_path, class: "nav-link" %>
+          <% elsif Rails.env.development? && ENV['FORCE_AMAZON_LOGIN'] != 'true' %>
+            <%= link_to "Log In (Development)", signin_path, class: "nav-link" %>
           <% else %>
             <%= link_to "Log In", signin_path, class: "nav-link" %>
           <% end %>

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -3,4 +3,6 @@ Rails.application.config.middleware.use OmniAuth::Builder do
     {
       :scope => 'profile postal_code' # default scope
     }
+
+  provider :developer if Rails.env.development?
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
   # OAuth
   controller :sessions do
     get '/auth/:provider/callback', action: :create
+    post '/auth/:provider/callback', action: :create
     get '/auth/failure', action: :failure
 
     get '/signin', action: :new, as: :signin


### PR DESCRIPTION
Resolves #73

Hello, I've enabled development login as needed in issue #73. Now when you signin, you should see this screen:

![image](https://user-images.githubusercontent.com/3189895/31317338-54c3006a-ac15-11e7-96f3-5d10737d9f2e.png)

And you can choose which authentication to use in development by using the environment variable `FORCE_AMAZON_LOGIN`. (true/false)

It disables csrf protection only in development mode and to the developer auth provider.