### PR TITLE
Remove br tags from pledge show page

### DIFF
--- a/app/views/pledges/show.html.erb
+++ b/app/views/pledges/show.html.erb
@@ -4,24 +4,24 @@
     "<%= @pledge.wishlist_item.name %>"
   </h2>
 
-  <p class="lead">
-    <% if @pledge.anonymous? %>
-      Thank you for being a Hero of Play! ♥
-  </p>
-  <p class="lead">
-      But wait, we don't know who you are! By logging in, you make it much
-      easier for us to track donations. Sign up/log in with Amazon <%= link_to "here", signin_path %>.
-    <% else %>
-      Thanks for being a Hero of Play! On behalf of the children and families we serve, thank you! ♥
-    <% end %>
-  </p>
+  <div class="my-4">
+    <p class="lead">
+      <% if @pledge.anonymous? %>
+        Thank you for being a Hero of Play! ♥
+    </p>
+    <p class="lead">
+        But wait, we don't know who you are! By logging in, you make it much
+        easier for us to track donations. Sign up/log in with Amazon <%= link_to "here", signin_path %>.
+      <% else %>
+        Thanks for being a Hero of Play! On behalf of the children and families we serve, thank you! ♥
+      <% end %>
+    </p>
+  </div>
 
   <%= render @pledge %>
 
-  <br /><br />
-
   <% if @pledge.anonymous? && current_user.logged_in? %>
-    <div class="row align-items-center unpledge">
+    <div class="row align-items-center unpledge my-4">
       <div class="col">
         <h4>Did you make this pledge?
         <%= link_to 'Claim pledge', pledge_claim_path(@pledge),
@@ -32,7 +32,7 @@
     </div>
   <% end %>
 
-  <div class="row align-items-center unpledge">
+  <div class="row align-items-center unpledge my-4">
     <div class="col">
       <h4>Didn't mean to pledge?
       <%= link_to 'Unpledge item', pledge_path(@pledge),


### PR DESCRIPTION
***Why is this change necessary?***
To remove use of br tags and rely on pure css for margin/ padding

***How does this accomplish the change?***
Used css classes provided by bootstrap to add top and bottom margin in lieu of br tags

***Side effects/ Notes***
I added the same css class with a wrapper div to the lead text as well as it was looking too close to the borders or elements above and below it

### Screenshots

#### Before
<img width="1173" alt="screen shot 2017-10-10 at 11 27 09 pm" src="https://user-images.githubusercontent.com/3662050/31421233-4f1834cc-ae14-11e7-9e9b-073ace0846ca.png">
<img width="985" alt="screen shot 2017-10-10 at 11 27 18 pm" src="https://user-images.githubusercontent.com/3662050/31421234-4f217adc-ae14-11e7-9ef8-a4479016037e.png">

#### After
<img width="955" alt="screen shot 2017-10-10 at 11 26 05 pm" src="https://user-images.githubusercontent.com/3662050/31421224-3bea371a-ae14-11e7-990a-a16d289d8c8b.png">
<img width="1215" alt="screen shot 2017-10-10 at 11 26 16 pm" src="https://user-images.githubusercontent.com/3662050/31421225-3c0f19fe-ae14-11e7-9934-b9fdfc18aab4.png">


