### PR TITLE
Open external Amazon links in a new window/tab

### DIFF
--- a/app/views/pledges/_pledge.html.erb
+++ b/app/views/pledges/_pledge.html.erb
@@ -11,8 +11,12 @@
         <div class="row">
           <h4 class="card-title col">
             <%= pledge.item_name %>
+
             <% if pledge.amazon_url %>
-              <small><%= link_to icon('external-link', 'Amazon'), pledge.amazon_url %></small>
+              <small>
+                <%= link_to icon('external-link', 'Amazon'), pledge.amazon_url,
+                  target: '_blank' %>
+              </small>
             <% end %>
           </h4>
         </div>

--- a/app/views/wishlist_items/_wishlist_item.html.erb
+++ b/app/views/wishlist_items/_wishlist_item.html.erb
@@ -11,8 +11,12 @@
         <div class="row">
           <h4 class="card-title">
             <%= wishlist_item.name %>
+
             <% if wishlist_item.amazon_url %>
-              <small><%= link_to icon('external-link', 'Amazon'), wishlist_item.amazon_url %></small>
+              <small>
+                <%= link_to icon('external-link', 'Amazon'),
+                  wishlist_item.amazon_url, target: '_blank' %>
+              </small>
             <% end %>
           </h4>
         </div>


### PR DESCRIPTION
Since these links are explicitly marked as external by the icon, it's
safe to open them in a new window/tab.

![fv8zjlngll](https://user-images.githubusercontent.com/381395/31686855-e08f6daa-b35d-11e7-9f1c-52802c1bbbd6.gif)
