### PR TITLE
Transient Spec Fix

### DIFF
--- a/spec/features/managing_users_spec.rb
+++ b/spec/features/managing_users_spec.rb
@@ -77,11 +77,12 @@ feature "Managing Users:" do
     end
 
     scenario "I can delete a user account" do
-      create(:user) # so we're not deleting our own account
+      user = create(:user) # so we're not deleting our own account
 
       click_link "Users"
       users = find_all(".user")
-      within(users.last) do
+      target_user_node = users.find { |user_element| user_element.text.include?(user.email) }
+      within(target_user_node) do
         click_link "Destroy"
       end
 


### PR DESCRIPTION
Resolves https://github.com/rubyforgood/playtime/issues/128

Changes:

  * Targets a specific user to destroy in spec to prevent transient errors.

NB: `User.all` does not guarantee ordering by ID unless you define a `default_scope` for the model.

🎩 
<img width="412" alt="screenshot 2017-10-19 13 03 02" src="https://user-images.githubusercontent.com/8755434/31792333-7d61e658-b4d0-11e7-8c2f-508aeacb4bb3.png">
<img width="247" alt="screenshot 2017-10-19 13 13 34" src="https://user-images.githubusercontent.com/8755434/31792334-7d842ba0-b4d0-11e7-8310-db65c089e4ba.png">