### PR TITLE
Rspec syntax mod for valid_image check

### DIFF
--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -10,7 +10,7 @@
       <%= hidden_field_tag 'image_height', item.image_height %>
 
       <td>
-        <% if item.has_valid_image? %>
+        <% if item.valid_image? %>
           <%= image_tag item.image_url, width: item.image_width,
                                         height: item.image_height %>
         <% end %>

--- a/lib/amazon_product_api/search_item.rb
+++ b/lib/amazon_product_api/search_item.rb
@@ -31,7 +31,7 @@ module AmazonProductAPI
       price != "$0.00"
     end
 
-    def has_valid_image?
+    def valid_image?
       image.valid?
     end
 

--- a/spec/lib/amazon_product_api/search_item_spec.rb
+++ b/spec/lib/amazon_product_api/search_item_spec.rb
@@ -14,18 +14,18 @@ describe AmazonProductAPI::SearchItem do
   end
 
   describe "#valid_image?" do
-    context "when all image attributes are valid" do
-      subject { AmazonProductAPI::SearchItem.new(image_url: "image url",
-                                                 image_height: 600,
-                                                 image_width: 800) }
-      it { should have_valid_image }
+    it "returns true for valid data" do
+      item = AmazonProductAPI::SearchItem.new(image_url: "image url",
+                                              image_height: 600,
+                                              image_width: 800)
+      expect(item.valid_image?).to eq true
     end
 
-    context "when there is no image url" do
-      subject { AmazonProductAPI::SearchItem.new(image_url: nil,
-                                                 image_height: 100,
-                                                 image_width: 100) }
-      it { should_not have_valid_image }
+    it "returns false for invalid data" do
+      item = AmazonProductAPI::SearchItem.new(image_url: nil,
+                                              image_height: 600,
+                                              image_width: 800)
+      expect(item.valid_image?).to eq false
     end
   end
 end


### PR DESCRIPTION
### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

One of the Rubocop violations we've got is for `lib/amazon_product_api/search_item.rb` violating the `Naming/PredicateName` cop. Basically, it says that when running a method ending in a question mark(a true/false method) that is also named with is_, has_, etc, that it should have the beginning predicate dropped as it that can be implied. Aka change `is_tall?` to `tall?` For us, this means `has_valid_image?` would turn into `valid_image?`. 

Here's where some of my greenness may be showing: In working to change that method, rspec specifically would throw an undefined method error instead of correctly calling `valid_image?`. In digging into it, it _seems_ to me that the object being called might not be the same one we were creating in the context step. I've been able to remedy this by switching up our usage of Rspec. It checks the same thing just does it differently. This 'differently' makes sure we're able to specify the exact object we want to test against and makes things happy.

Let me know your thoughts on this. If you're not into it or have another way, let me know.  I know using `expect` is a departure from the repo's wide-spread usage of `should`, but it solves this case well!

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

`bundle exec rake` passes: ✅ 