### PR TITLE
Fixes issue 60. Connection errors and non successful responses from …

### DIFF
--- a/app/controllers/amazon_search_controller.rb
+++ b/app/controllers/amazon_search_controller.rb
@@ -10,6 +10,9 @@ class AmazonSearchController < ApplicationController
   def show
     authorize :amazon_search, :show?
     @response = amazon_search_response
+    if @response.error?
+      redirect_to new_wishlist_amazon_search_path(params[:wishlist_id]), notice: 'Could not connect to Amazon. Please try again later or contact the website adminitrator.'
+    end
   end
 
   def new

--- a/lib/amazon_product_api/item_search_endpoint.rb
+++ b/lib/amazon_product_api/item_search_endpoint.rb
@@ -46,9 +46,10 @@ module AmazonProductAPI
     def response(http: HTTParty, logger: Rails.logger)
       begin
         response = get(http: http)
+        logger.debug response
         SearchResponse.new(parse_response(response), response.code)
-      rescue StandardError
-        Rails.logger.error("Failed to connect to Amazon. Reqeust: #{http}")
+      rescue StandardError => e
+        Rollbar.error(e, "Failed to connect to Amazon. Reqeust: #{http}")
         SearchResponse.new({}, 500)
       end
     end

--- a/lib/amazon_product_api/item_search_endpoint.rb
+++ b/lib/amazon_product_api/item_search_endpoint.rb
@@ -44,9 +44,13 @@ module AmazonProductAPI
 
     # Performs the search query and returns the resulting SearchResponse
     def response(http: HTTParty, logger: Rails.logger)
-      response = parse_response get(http: http)
-      logger.debug response
-      SearchResponse.new response
+      begin
+        response = get(http: http)
+        SearchResponse.new(parse_response(response), response.code)
+      rescue StandardError
+        Rails.logger.error("Failed to connect to Amazon. Reqeust: #{http}")
+        SearchResponse.new({}, 500)
+      end
     end
 
     private

--- a/lib/amazon_product_api/search_response.rb
+++ b/lib/amazon_product_api/search_response.rb
@@ -9,8 +9,14 @@ module AmazonProductAPI
   # this class. By isolating it from the rest of the codebase, we only have one
   # file to touch if the API response changes.
   class SearchResponse
-    def initialize(response_hash)
+
+    SUCCESS_CODE_RANGE = (200..299)
+    FOUND_CODE = 302
+    NOT_MODIFIED = 304
+
+    def initialize(response_hash, code)
       @response_hash = response_hash
+      @code = code
     end
 
     def num_pages
@@ -21,9 +27,17 @@ module AmazonProductAPI
       item_hashes.map { |hash| item_class.new(**item_attrs_from(hash)) }
     end
 
+    def success?
+      SUCCESS_CODE_RANGE.include?(code) || [FOUND_CODE, NOT_MODIFIED].include?(code)
+    end
+
+    def error?
+      !success?
+    end
+
     private
 
-    attr_reader :response_hash
+    attr_reader :response_hash, :code
 
     def item_attrs_from(hash)
       {

--- a/lib/amazon_product_api/search_response.rb
+++ b/lib/amazon_product_api/search_response.rb
@@ -13,6 +13,7 @@ module AmazonProductAPI
     SUCCESS_CODE_RANGE = (200..299)
     FOUND_CODE = 302
     NOT_MODIFIED = 304
+    SUCCESS_CODES = SUCCESS_CODE_RANGE.to_a + [FOUND_CODE, NOT_MODIFIED]
 
     def initialize(response_hash, code)
       @response_hash = response_hash
@@ -28,7 +29,7 @@ module AmazonProductAPI
     end
 
     def success?
-      SUCCESS_CODE_RANGE.include?(code) || [FOUND_CODE, NOT_MODIFIED].include?(code)
+      SUCCESS_CODES.include?(code)
     end
 
     def error?

--- a/spec/features/managing_items_and_wishlists_spec.rb
+++ b/spec/features/managing_items_and_wishlists_spec.rb
@@ -35,6 +35,26 @@ feature 'Managing items and wishlists:' do
       expect(page).to have_text 'Needed: 18'
     end
 
+    scenario "I get redirected to the search page when Amazon returns an error code.", :external do
+      allow_any_instance_of(HTTParty::Response).to receive(:code).and_return(500)
+      visit wishlist_path(wishlist)
+      click_link "Add to Wishlist"
+      fill_in "search_field", with: "corgi"
+      click_button "Search Amazon"
+
+      expect(page).to have_text 'Could not connect to Amazon'
+    end
+
+    scenario "I get redirected to the search page when the call to Amazon to connect.", :external do
+      allow(HTTParty).to receive(:get).and_raise(HTTParty::Error)
+      visit wishlist_path(wishlist)
+      click_link "Add to Wishlist"
+      fill_in "search_field", with: "corgi"
+      click_button "Search Amazon"
+
+      expect(page).to have_text 'Could not connect to Amazon'
+    end
+
     scenario "My search can't be blank", :external do
       visit wishlist_path(wishlist)
       click_link 'Add to Wishlist'

--- a/spec/features/managing_items_and_wishlists_spec.rb
+++ b/spec/features/managing_items_and_wishlists_spec.rb
@@ -36,10 +36,9 @@ feature 'Managing items and wishlists:' do
     end
 
     scenario "I get redirected to the search page when Amazon returns an error code.", :external do
-      allow_any_instance_of(HTTParty::Response).to receive(:code).and_return(500)
       visit wishlist_path(wishlist)
       click_link "Add to Wishlist"
-      fill_in "search_field", with: "corgi"
+      fill_in "search_field", with: "return an error" # Triggers webmock to return 500
       click_button "Search Amazon"
 
       expect(page).to have_text 'Could not connect to Amazon'

--- a/spec/lib/amazon_product_api/search_response_spec.rb
+++ b/spec/lib/amazon_product_api/search_response_spec.rb
@@ -15,6 +15,8 @@ describe AmazonProductAPI::SearchResponse do
   end
   let(:blank_response) { AmazonProductAPI::SearchResponse.new({}, 200) }
   let(:full_response)  { AmazonProductAPI::SearchResponse.new(response_hash, 200) }
+  let(:success_codes) { [ 200, 204, 302, 304 ] }
+  let(:failure_codes) { [ 400, 500 ] }
 
   describe '#num_pages' do
     context 'no page number is present' do
@@ -49,14 +51,14 @@ describe AmazonProductAPI::SearchResponse do
   describe '#success' do
     context 'a successfull response' do
       it 'should return true for success codes' do
-        [ 200, 204, 302, 304 ].each do |code|
+        success_codes.each do |code|
           response = AmazonProductAPI::SearchResponse.new({}, code)
           expect(response.success?).to be(true), "expected true, got #{response.success?} for code #{code}"
         end
       end
 
       it 'should return false for non-success codes' do
-        [ 400, 500 ].each do |code|
+        failure_codes.each do |code|
           response = AmazonProductAPI::SearchResponse.new({}, code)
           expect(response.success?).to be(false), "expected false, got #{response.success?} for code #{code}"
         end
@@ -67,14 +69,14 @@ describe AmazonProductAPI::SearchResponse do
   describe '#error' do
     context 'a successfull response' do
       it 'should return false for success codes' do
-        [ 200, 204, 302, 304 ].each do |code|
+        success_codes.each do |code|
           response = AmazonProductAPI::SearchResponse.new({}, code)
           expect(response.error?).to be(false), "expected false, got #{response.success?} for code #{code}"
         end
       end
 
       it 'should return true for non-success codes' do
-        [ 400, 500 ].each do |code|
+        failure_codes.each do |code|
           response = AmazonProductAPI::SearchResponse.new({}, code)
           expect(response.error?).to be(true), "expected true, got #{response.success?} for code #{code}"
         end

--- a/spec/lib/amazon_product_api/search_response_spec.rb
+++ b/spec/lib/amazon_product_api/search_response_spec.rb
@@ -13,8 +13,8 @@ describe AmazonProductAPI::SearchResponse do
       }
     }
   end
-  let(:blank_response) { AmazonProductAPI::SearchResponse.new({}) }
-  let(:full_response)  { AmazonProductAPI::SearchResponse.new(response_hash) }
+  let(:blank_response) { AmazonProductAPI::SearchResponse.new({}, 200) }
+  let(:full_response)  { AmazonProductAPI::SearchResponse.new(response_hash, 200) }
 
   describe '#num_pages' do
     context 'no page number is present' do
@@ -42,6 +42,42 @@ describe AmazonProductAPI::SearchResponse do
       it 'should create the correct number of new items' do
         expect(mock_item_class).to receive(:new).exactly(3).times
         items
+      end
+    end
+  end
+
+  describe '#success' do
+    context 'a successfull response' do
+      it 'should return true for success codes' do
+        [ 200, 204, 302, 304 ].each do |code|
+          response = AmazonProductAPI::SearchResponse.new({}, code)
+          expect(response.success?).to be(true), "expected true, got #{response.success?} for code #{code}"
+        end
+      end
+
+      it 'should return false for non-success codes' do
+        [ 400, 500 ].each do |code|
+          response = AmazonProductAPI::SearchResponse.new({}, code)
+          expect(response.success?).to be(false), "expected false, got #{response.success?} for code #{code}"
+        end
+      end
+    end
+  end
+
+  describe '#error' do
+    context 'a successfull response' do
+      it 'should return false for success codes' do
+        [ 200, 204, 302, 304 ].each do |code|
+          response = AmazonProductAPI::SearchResponse.new({}, code)
+          expect(response.error?).to be(false), "expected false, got #{response.success?} for code #{code}"
+        end
+      end
+
+      it 'should return true for non-success codes' do
+        [ 400, 500 ].each do |code|
+          response = AmazonProductAPI::SearchResponse.new({}, code)
+          expect(response.error?).to be(true), "expected true, got #{response.success?} for code #{code}"
+        end
       end
     end
   end

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -19,5 +19,9 @@ RSpec.configure do |config|
       .with(query: hash_including('Operation' => 'ItemLookup',
                                   'ItemId' => 'corgi_asin'))
       .to_return(body: lookup_response)
+
+    stub_request(:get, 'webservices.amazon.com/onca/xml')
+      .with(query: hash_including('Keywords' => 'return an error'))
+      .to_return(status: 500)
   end
 end


### PR DESCRIPTION
…Amazon are handled by redirecting the user to the search page and providing an error message.

Resolves #60 

### Description
Currently if searching Amazon fails to connect or returns a non-success http response code (such as 500), we do not handle it. This PR will catch network connection errors as well as error code responses and redirect the user to the search page and flash a message.

This solution allows any http response in the 200 range and 302, and 304. All 200's are considered successful, so we should accept them. 302 and 304 are less common, but they sometimes occur because of http caching (I think), so we should catch them too. Being more restrictive might cause good, useful responses to be lost and frustrate the user.

### Type of change
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
Can be tested by running rspec. New specs have been written to cover response code cases and http error cases.

Manual testing network errors:

1. Go to the search page.
2. Disconnect from the internet.
3. Do a search.
You will see the error message.

Manual testing http response errors:

1. Edit the SearchResponse#error? method to always return true.
2. Go to the search page and do a search.
You will see the error message.
