### PR TITLE
Add Rubocop to PR Template Checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,7 @@
 - I have made corresponding changes to the documentation,
 - I have added tests that prove my fix is effective or that my feature works,
 - New and existing unit tests pass locally with my changes ("bundle exec rake"),
+- Ruby style passes ("bundle exec rubocop"),
 - Title include "WIP" if work is in progress.
 
 -->


### PR DESCRIPTION
### Description

As a new contributor I wasn't aware that this project uses Rubocop. Added a bullet in the PR Template Checklist to run Rubocop.

### Type of change

* Documentation update
