### PR TITLE
Updates to ensure new tab is opened for all pledges

### DIFF
--- a/app/assets/javascripts/pledges.js
+++ b/app/assets/javascripts/pledges.js
@@ -15,5 +15,5 @@ ready = function() {
     });
 };
 
-$(document).ready(ready);
-$(document).on('page:load', ready);
+// starts event listener on turbolinks load
+$(document).on('turbolinks:load', ready);


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Ruby style passes ("bundle exec rubocop"),

-->

Resolves #195 

## Description
This PR is in response to issue #195 which described an issue where a logged in user was not getting a new tab opened to the item's amazon page when they clicked on 'Pledge to Donate' from the home page.  After initial review, the issue looked to be much broader in scope - and is described below:

### Expected Behavior:
As a user (logged in or not)
When I visit the root page
And click on 'Pledge To Donate'
A new tab is opened with the item's amazon url
And the current page is redirected to the pledges page
Then when I click on 'home'
And click on 'Pledge to Donate'
A new tab is opened with the item's amazon url
And the current page is redirected to the pledges page

### Actual Behavior:
As a user (logged in or not)
When I visit the root page
And click on 'Pledge To Donate'
A new tab is opened with the item's amazon url
And the current page is redirected to the pledges page
Then when I click on 'home'
And click on 'Pledge to Donate'
Then the current page is redirected to the pledges page

-- OR --

As a user (logged in or not)
When I visit the root page
And click on 'Pledge To Donate'
A new tab is opened with the item's amazon url
And the current page is redirected to the pledges page
Then when I click on my browser's back button
A new tab is opened with the item's amazon url
And the current page is redirected to the pledges page

As outlined above, the issue is that the expected behavior (a new tab being opened) is only happening the first time the home page is loaded and subsequently, only if the browser's back button is used.  The fix should allow for the expected behavior regardless of the user's method of returning to the home page.

This pull request fixes this issue by changing the document ready function in pledges.js to be triggered when turbolinks loads, rather than when the page loads.  With turbolinks enabled, the home page is not being fully loaded when the home button is clicked, and so the previous configuration was missing the pickup of the new tab event listener.  The change to turbolinks:load from page:load fixes the issue for all users, whether logged in, or not.


## Type of change

* Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?

I have user-tested this locally with chrome, firefox and safari with the steps outlined below:
As a guest:
1.  Start you local server: `rails server`
2. Navigate to localhost:3000 in your browser of choice
3. Click on any 'Pledge to Donate' button
4. A new tab should open, taking you to the amazon page for that item
5. Click back to the 'Playtime' tab
6. Click on 'Home'
7. Click on any 'Pledge to Donate' button
8. A new tab should open, taking you to the amazon page for that item

As a logged in user:
1.  Start you local server: `rails server`
2. Navigate to localhost:3000 in your browser of choice
3. Click on Log In
4. Enter your Name and Email
5. Click on Sign In
6. Click on any 'Pledge to Donate' button
7. A new tab should open, taking you to the amazon page for that item
8. Click back to the 'Playtime' tab
9. Click on 'Home'
10. Click on any 'Pledge to Donate' button
11. A new tab should open, taking you to the amazon page for that item
